### PR TITLE
Allow admins to pass the record or not.Close #113

### DIFF
--- a/src/app/data-management/components/data-review/data-review.component.html
+++ b/src/app/data-management/components/data-review/data-review.component.html
@@ -140,8 +140,8 @@
               <button mat-raised-button type="button" (click)="onSubmit()" class="btn btn-danger">提交</button>
             </div>
             <div fxLayout="row" fxLayoutAlign="end stretch" fxLayoutGap="5px">
-              <button mat-raised-button class="btn btn-danger">通过</button>
-              <button mat-raised-button class="btn btn-danger">不通过</button>
+              <button mat-raised-button class="btn btn-danger" (click)="statuschange('通过')">通过</button>
+              <button mat-raised-button class="btn btn-danger" (click)="statuschange('不通过')">不通过</button>
               <button mat-raised-button class="btn btn-danger">返回</button>
             </div>
 

--- a/src/app/data-management/components/data-review/data-review.component.spec.ts
+++ b/src/app/data-management/components/data-review/data-review.component.spec.ts
@@ -261,7 +261,6 @@ describe('DataReviewComponent', () => {
                         };
     component.statuschange(message);
     expect(component.record.status).toBe(RecordStatus.STATUS_SUBMITTED);
-    console.log(component.record.status);
     expect(snackBarOpen).toHaveBeenCalledWith('培训记录不合格，未通过审核！', '关闭');
     component.record = { id: 1,
                          create_time: '2019-01-01',

--- a/src/app/data-management/components/data-review/data-review.component.ts
+++ b/src/app/data-management/components/data-review/data-review.component.ts
@@ -42,6 +42,7 @@ export class DataReviewComponent extends GenericListComponent<ReviewNoteResponse
     return this.reviewnoteService.getReviewNotes({offset, limit, extraParams});
   }
 
+  /** Submit review note created by admins. */
   onSubmit() {
     this.reviewnoteService.createReviewNote(this.record, this.reviewnotecontent)
     .subscribe(res => {
@@ -61,6 +62,7 @@ export class DataReviewComponent extends GenericListComponent<ReviewNoteResponse
     );
   }
 
+  /** Allow admins to change record status. */
   statuschange(message: string) {
     const prestatus = this.record.status;
     const isDepartmentAdmin = this.authService.isDepartmentAdmin;

--- a/src/app/training-record/services/record.service.spec.ts
+++ b/src/app/training-record/services/record.service.spec.ts
@@ -7,6 +7,7 @@ import { RecordService } from './record.service';
 import { environment } from 'src/environments/environment';
 import { RecordRequest } from 'src/app/shared/interfaces/record';
 import { ContentType } from 'src/app/shared/enums/content-type.enum';
+import { RecordStatus } from 'src/app/shared/enums/record-status.enum';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 
 describe('RecordService', () => {
@@ -151,6 +152,18 @@ describe('RecordService', () => {
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('POST');
+    req.flush({});
+  });
+
+  it('should update record status', () => {
+    const service: RecordService = TestBed.get(RecordService);
+
+    service.updateRecordStatus(1, RecordStatus.STATUS_FACULTY_ADMIN_REVIEWED).subscribe();
+
+    const url = `${environment.API_URL}/records/1/`;
+
+    const req = httpTestingController.expectOne(url);
+    expect(req.request.method).toEqual('PATCH');
     req.flush({});
   });
 

--- a/src/app/training-record/services/record.service.ts
+++ b/src/app/training-record/services/record.service.ts
@@ -65,4 +65,11 @@ export class RecordService extends GenericListService {
     data.set('file', file);
     return this.http.post<{'count': number}>(`${environment.API_URL}/records/actions/batch-submit/`, data);
   }
+
+  updateRecordStatus(id: number, status: number) {
+    const data = new FormData();
+    data.set('status', status.toString());
+    return this.http.patch<RecordResponse>(
+      `${environment.API_URL}/records/${id}/`, data);
+  }
 }


### PR DESCRIPTION
Before operation, the page looks like this
![image](https://user-images.githubusercontent.com/41313468/56044110-1403ed00-5d71-11e9-8735-95040b49654d.png)
After faculty admin pass the record, the page changes.
![image](https://user-images.githubusercontent.com/41313468/56044226-457cb880-5d71-11e9-99ec-182126c85000.png)
After school admin pass the record, the page changes too.
![image](https://user-images.githubusercontent.com/41313468/56044416-b3c17b00-5d71-11e9-8cf4-3df82b1aeb1f.png)
If admins don't have enough permission, they can't change record status.
![image](https://user-images.githubusercontent.com/41313468/56044539-f5eabc80-5d71-11e9-8edf-2eab14f8a41b.png)

