### PR TITLE
Fix a bug in forceRefresh(), close #137.

### DIFF
--- a/src/app/shared/generics/generic-list/generic-list.spec.ts
+++ b/src/app/shared/generics/generic-list/generic-list.spec.ts
@@ -5,10 +5,10 @@ import { GenericListComponent } from './generic-list';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
 import { GenericObject } from 'src/app/shared/interfaces/generics';
 import { ActivatedRoute, Router } from '@angular/router';
-import { MatPaginatorModule } from '@angular/material';
 import { Component } from '@angular/core';
 import { HAMMER_LOADER } from '@angular/platform-browser';
 import { Location } from '@angular/common';
+import { MatPaginatorModule } from '@angular/material';
 
 @Component({
     selector: 'app-list-component',
@@ -120,10 +120,26 @@ describe('GenericListComponent', () => {
         expect(navigate).toHaveBeenCalled();
     });
 
-    it('should trigger refresh', () => {
+    it('should trigger refresh (at first page)', () => {
+        const hasPreviousPage = spyOn(component.paginator, 'hasPreviousPage');
+        const firstPage = spyOn(component.paginator, 'firstPage');
+        hasPreviousPage.and.returnValue(true);
         component.forceRefresh();
 
+        expect(hasPreviousPage).toHaveBeenCalled();
+        expect(firstPage).toHaveBeenCalled();
+    });
+
+    it('should trigger refresh (not at first page)', () => {
+        const hasPreviousPage = spyOn(component.paginator, 'hasPreviousPage');
+        const firstPage = spyOn(component.paginator, 'firstPage');
+        hasPreviousPage.and.returnValue(false);
+        component.forceRefresh();
+
+        expect(hasPreviousPage).toHaveBeenCalled();
+        expect(firstPage).not.toHaveBeenCalled();
         expect(go).toHaveBeenCalled();
         expect(getResults).toHaveBeenCalled();
     });
+
 });

--- a/src/app/shared/generics/generic-list/generic-list.ts
+++ b/src/app/shared/generics/generic-list/generic-list.ts
@@ -74,6 +74,13 @@ export abstract class GenericListComponent<T extends GenericObject> implements O
 
   /** Trigger page refresh manually. */
   forceRefresh() {
+    if (this.paginator.hasPreviousPage()) {
+      // Not at first page. Jump to first page and content will be udpated
+      // accordingly
+      this.paginator.firstPage();
+      return;
+    }
+    // At first page, just trigger content refresh
     this.forceRefresh$.next({
       pageIndex: 0,
     } as PageEvent);


### PR DESCRIPTION
`forceRefresh()` should update paginator state when updating the page content. If paginator is at first page, then there is no need to update the page number, otherwise just jump to first page.