### PR TITLE
Unify request and response objects.

### DIFF
--- a/src/app/core/notification-detail/notification-detail-resolver.service.ts
+++ b/src/app/core/notification-detail/notification-detail-resolver.service.ts
@@ -3,19 +3,19 @@ import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/r
 import { Observable } from 'rxjs';
 
 import { NotificationService } from 'src/app/shared/services/notification.service';
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 
 /** Pre-fetching notification data. */
 @Injectable({
   providedIn: 'root'
 })
-export class NotificationDetailResolverService implements Resolve<NotificationResponse> {
+export class NotificationDetailResolverService implements Resolve<Notification> {
 
   constructor(
     private readonly notificationService: NotificationService,
   ) { }
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<NotificationResponse> {
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Notification> {
     const id = +route.paramMap.get('id');
     return this.notificationService.getNotification(id);
   }

--- a/src/app/core/notification-detail/notification-detail.component.spec.ts
+++ b/src/app/core/notification-detail/notification-detail.component.spec.ts
@@ -5,7 +5,7 @@ import { MatCardModule, MatDividerModule } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 
 import { NotificationDetailComponent } from './notification-detail.component';
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 
 
 describe('NotificationDetailComponent', () => {
@@ -33,12 +33,12 @@ describe('NotificationDetailComponent', () => {
           useValue: {
             data: observableOf({notification: {
               id: 1,
-              sender: 'sender',
-              recipient: 'recipient',
+              sender: 2,
+              recipient: 3,
               content: 'content',
               time: '2019-01-01',
               read_time: '2019-01-01',
-            } as NotificationResponse}),
+            } as Notification}),
           },
         }
       ]

--- a/src/app/core/notification-detail/notification-detail.component.ts
+++ b/src/app/core/notification-detail/notification-detail.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 
 /** Display a notification in detail. */
 @Component({
@@ -12,14 +12,14 @@ import { NotificationResponse } from 'src/app/shared/interfaces/notification';
 })
 export class NotificationDetailComponent implements OnInit {
   /** The data to be displayed. */
-  notification: NotificationResponse;
+  notification: Notification;
   constructor(
     private readonly route: ActivatedRoute,
     readonly location: Location,
   ) { }
 
   ngOnInit() {
-    this.route.data.subscribe((data: { notification: NotificationResponse}) => {
+    this.route.data.subscribe((data: { notification: Notification}) => {
       this.notification = data.notification;
     });
   }

--- a/src/app/core/notification-list/notification-list.component.spec.ts
+++ b/src/app/core/notification-list/notification-list.component.spec.ts
@@ -4,7 +4,7 @@ import { MatProgressSpinnerModule, MatPaginatorModule, MatIconModule } from '@an
 import { ActivatedRoute, Router } from '@angular/router';
 import { of as observableOf, Subject } from 'rxjs';
 
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 import { NotificationService } from 'src/app/shared/services/notification.service';
 import { NotificationListComponent } from './notification-list.component';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
@@ -14,23 +14,23 @@ import { Location } from '@angular/common';
 describe('NotificationListComponent', () => {
   let component: NotificationListComponent;
   let fixture: ComponentFixture<NotificationListComponent>;
-  let getNotifications$: Subject<PaginatedResponse<NotificationResponse>>;
+  let getNotifications$: Subject<PaginatedResponse<Notification>>;
   let navigate: jasmine.Spy;
   let getNotifications: jasmine.Spy;
   let markAllNotificationsAsRead: jasmine.Spy;
   let deleteAllNotifications: jasmine.Spy;
-  const dummyNotification: NotificationResponse = {
+  const dummyNotification: Notification = {
     id: 2,
     time: '2019-01-01',
-    sender: 'sender',
-    recipient: 'recipient',
+    sender: 2,
+    recipient: 3,
     content: 'content',
     read_time: '2019-01-01',
   };
 
   beforeEach(async(() => {
     navigate = jasmine.createSpy();
-    getNotifications$ = new Subject<PaginatedResponse<NotificationResponse>>();
+    getNotifications$ = new Subject<PaginatedResponse<Notification>>();
     getNotifications = jasmine.createSpy();
     getNotifications.and.returnValue(getNotifications$);
     markAllNotificationsAsRead = jasmine.createSpy();
@@ -100,7 +100,7 @@ describe('NotificationListComponent', () => {
 
   it('should mark all notifications as read', () => {
     const count = 100;
-    const results: NotificationResponse[] = [dummyNotification, dummyNotification];
+    const results: Notification[] = [dummyNotification, dummyNotification];
     const forceRefresh = spyOn(component, 'forceRefresh');
     getNotifications$.next({ count, results, next: '', previous: '' });
     markAllNotificationsAsRead.and.returnValue(observableOf(null));
@@ -113,7 +113,7 @@ describe('NotificationListComponent', () => {
 
   it('should delete all notifications.', () => {
     const count = 100;
-    const results: NotificationResponse[] = [dummyNotification, dummyNotification];
+    const results: Notification[] = [dummyNotification, dummyNotification];
     const forceRefresh = spyOn(component, 'forceRefresh');
     getNotifications$.next({ count, results, next: '', previous: '' });
     deleteAllNotifications.and.returnValue(observableOf(null));

--- a/src/app/core/notification-list/notification-list.component.ts
+++ b/src/app/core/notification-list/notification-list.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 import { NotificationService } from 'src/app/shared/services/notification.service';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
 
@@ -12,7 +12,7 @@ import { GenericListComponent } from 'src/app/shared/generics/generic-list/gener
   templateUrl: './notification-list.component.html',
   styleUrls: ['./notification-list.component.css']
 })
-export class NotificationListComponent extends GenericListComponent<NotificationResponse> {
+export class NotificationListComponent extends GenericListComponent<Notification> {
   constructor(
     protected readonly route: ActivatedRoute,
     protected readonly router: Router,

--- a/src/app/data-management/components/data-review/data-review.component.spec.ts
+++ b/src/app/data-management/components/data-review/data-review.component.spec.ts
@@ -18,7 +18,7 @@ import { Location } from '@angular/common';
 
 import { DataReviewComponent } from './data-review.component';
 import { OffCampusRecordDetailComponent } from 'src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 
 describe('DataReviewComponent', () => {
   let component: DataReviewComponent;
@@ -60,20 +60,11 @@ describe('DataReviewComponent', () => {
               create_time: '2019-01-01',
               update_time: '2019-01-02',
               campus_event: null,
-              off_campus_event: {id: 1,
-                                 create_time: '2019-03-02T09:07:57.159755+08:00',
-                                 update_time: '2019-03-02T09:07:57.159921+08:00',
-                                 name: 'sfdg',
-                                 time: '2019-03-02T00:00:00+08:00',
-                                 location: 'dfgfd',
-                                 num_hours: 0,
-                                 num_participants: 25
-                                 },
               contents: [],
               attachments: [],
               user: 1,
               status: 1,
-            } as RecordResponse}),
+            } as Record}),
           }
         },
         {

--- a/src/app/data-management/components/data-review/data-review.component.ts
+++ b/src/app/data-management/components/data-review/data-review.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 
 /** Display a record review page in detail. */
 @Component({
@@ -12,7 +12,7 @@ import { RecordResponse } from 'src/app/shared/interfaces/record';
 })
 export class DataReviewComponent implements OnInit {
   /** The data to be displayed. */
-  record: RecordResponse;
+  record: Record;
 
   constructor(
     protected readonly route: ActivatedRoute,
@@ -20,7 +20,7 @@ export class DataReviewComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.route.data.subscribe((data: { record: RecordResponse}) => {
+    this.route.data.subscribe((data: { record: Record}) => {
       this.record = data.record;
     });
   }

--- a/src/app/data-management/components/record-list/record-list.component.ts
+++ b/src/app/data-management/components/record-list/record-list.component.ts
@@ -2,7 +2,7 @@ import { Component} from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { RecordService } from 'src/app/training-record/services/record.service';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
 
@@ -12,7 +12,7 @@ import { GenericListComponent } from 'src/app/shared/generics/generic-list/gener
   templateUrl: './record-list.component.html',
   styleUrls: ['./record-list.component.css']
 })
-export class RecordListComponent extends GenericListComponent<RecordResponse> {
+export class RecordListComponent extends GenericListComponent<Record> {
   constructor(
     protected readonly route: ActivatedRoute,
     protected readonly router: Router,

--- a/src/app/data-management/services/review-note.service.spec.ts
+++ b/src/app/data-management/services/review-note.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { ReviewNoteService } from './review-note.service';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 
 import { environment } from 'src/environments/environment';
 
@@ -42,19 +42,9 @@ describe('ReviewNoteService', () => {
 
   it('should create reviewnote', () => {
     const service: ReviewNoteService = TestBed.get(ReviewNoteService);
-    const dres: RecordResponse = {
+    const dres: Record = {
       id: 1,
       campus_event: null,
-      off_campus_event: {
-        id: 1,
-        create_time: '2019-04-05T14:21:55.151136+08:00',
-        update_time: '2019-04-05T14:21:55.151190+08:00',
-        name: '为了其中主要公司.',
-        time: '2019-05-01T05:00:33.149789+08:00',
-        location: '哈尔滨路n座',
-        num_hours: 0.39234403748298163,
-        num_participants: 57
-      },
       attachments: null,
       contents: null,
       create_time: '2019-04-05T14:21:55.787056+08:00',

--- a/src/app/data-management/services/review-note.service.ts
+++ b/src/app/data-management/services/review-note.service.ts
@@ -3,8 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
-import { ReviewNoteResponse } from 'src/app/shared/interfaces/review-note';
+import { Record } from 'src/app/shared/interfaces/record';
+import { ReviewNote } from 'src/app/shared/interfaces/review-note';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
 
@@ -21,15 +21,15 @@ export class ReviewNoteService extends GenericListService {
   }
 
   getReviewNotes(req: ListRequest) {
-    return this.list<ReviewNoteResponse>('review-notes', req);
+    return this.list<ReviewNote>('review-notes', req);
   }
 
-  createReviewNote(dres: RecordResponse, notecontent: string): Observable<ReviewNoteResponse> {
+  createReviewNote(dres: Record, notecontent: string): Observable<ReviewNote> {
     const data = new FormData();
     data.set('content', notecontent);
     data.set('record', dres.id.toString());
     data.set('user', dres.user.toString());
-    return this.http.post<ReviewNoteResponse>(
+    return this.http.post<ReviewNote>(
       `${environment.API_URL}/review-notes/`, data);
   }
 }

--- a/src/app/permission-management/components/user-management/user-management.component.spec.ts
+++ b/src/app/permission-management/components/user-management/user-management.component.spec.ts
@@ -14,12 +14,12 @@ import {
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PermissionService } from 'src/app/shared/services/permission.service';
-import { UserPermissionRequest, UserPermissionStatus, Permission, UserPermission } from 'src/app/shared/interfaces/permission';
+import { UserPermissionStatus, Permission, UserPermission } from 'src/app/shared/interfaces/permission';
 import { Subject } from 'rxjs';
 import { UserService } from 'src/app/shared/services/user.service';
 import { DepartmentService } from 'src/app/shared/services/department.service';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
-import { User } from 'src/app/shared/interfaces/auth-service';
+import { User } from 'src/app/shared/interfaces/user';
 
 function generatePermissions(n?: number): Permission[] {
   n = n || 5;
@@ -108,7 +108,7 @@ describe('UserManagementComponent', () => {
             getPermissions: () => getPermissions$,
             getUserPermissions: (id: number) => getUserPermissions$,
             deleteUserPermissions: (permissionIds: number[]) => deleteUserPermissions$,
-            createUserPermissions: (reqs: UserPermissionRequest[]) => createUserPermissions$,
+            createUserPermissions: (reqs: UserPermission[]) => createUserPermissions$,
           },
         }
       ]

--- a/src/app/permission-management/components/user-management/user-management.component.ts
+++ b/src/app/permission-management/components/user-management/user-management.component.ts
@@ -1,12 +1,12 @@
 import { Component, OnInit } from '@angular/core';
-import { UserPermissionRequest, UserPermissionStatus, Permission, UserPermission } from 'src/app/shared/interfaces/permission';
+import { UserPermission, UserPermissionStatus, Permission } from 'src/app/shared/interfaces/permission';
 import { MatSnackBar } from '@angular/material';
 import { PermissionService } from 'src/app/shared/services/permission.service';
 import { of as observableOf, zip, throwError } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Department } from 'src/app/shared/interfaces/department';
-import { User } from 'src/app/shared/interfaces/auth-service';
+import { User } from 'src/app/shared/interfaces/user';
 import { UserService } from 'src/app/shared/services/user.service';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
 import { DepartmentService } from 'src/app/shared/services/department.service';
@@ -103,8 +103,8 @@ export class UserManagementComponent implements OnInit {
    * Populate what permissions we want to update,
    * skip permissions with no change.
    */
-  private diffPermissions(): [UserPermissionRequest[], number[]] {
-    const toBeCreated: UserPermissionRequest[] = [];
+  private diffPermissions(): [UserPermission[], number[]] {
+    const toBeCreated: UserPermission[] = [];
     const toBeDeleted: number[] = [];
 
     for (let i = 0; i < this.originalPermissions.length; i++) {

--- a/src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component.html
+++ b/src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component.html
@@ -3,7 +3,7 @@
     fxLayoutGap="15px">
     <span class="item-title" fxFlex="1 0 20%">项目名称</span>
     <div class="item-content" fxFlex="1 0 78%">
-      <p>{{ record.off_campus_event.name }}</p>
+      <!-- <p>{{ record.off_campus_event.name }}</p> -->
     </div>
     <div fxFlex="1 0 2%"></div>
   </div>
@@ -12,7 +12,7 @@
     fxLayoutGap="15px">
     <span class="item-title" fxFlex="1 0 20%">培训时间</span>
     <div class="item-content" fxFlex="1 0 78%">
-      <p>{{ record.off_campus_event.time | date:'y年M月d日 H:mm' }}</p>
+      <!-- <p>{{ record.off_campus_event.time | date:'y年M月d日 H:mm' }}</p> -->
     </div>
     <div fxFlex="1 0 2%"></div>
   </div>
@@ -21,7 +21,7 @@
     fxLayoutGap="15px">
     <span class="item-title" fxFlex="1 0 20%">培训地点</span>
     <div class="item-content" fxFlex="1 0 78%">
-      <p>{{ record.off_campus_event.location }}</p>
+      <!-- <p>{{ record.off_campus_event.location }}</p> -->
     </div>
     <div fxFlex="1 0 2%"></div>
   </div>
@@ -30,7 +30,7 @@
     fxLayoutGap="15px">
     <span class="item-title" fxFlex="1 0 20%">培训学时</span>
     <div class="item-content" fxFlex="1 0 78%">
-      <p>{{ record.off_campus_event.num_hours | number:"1.0-2" }}</p>
+      <!-- <p>{{ record.off_campus_event.num_hours | number:"1.0-2" }}</p> -->
     </div>
     <div fxFlex="1 0 2%"></div>
   </div>
@@ -39,7 +39,7 @@
     fxLayoutGap="15px">
     <span class="item-title" fxFlex="1 0 20%">参加人数</span>
     <div class="item-content" fxFlex="1 0 78%">
-      <p>{{ record.off_campus_event.num_participants }}</p>
+      <!-- <p>{{ record.off_campus_event.num_participants }}</p> -->
     </div>
     <div fxFlex="1 0 2%"></div>
   </div>

--- a/src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component.spec.ts
+++ b/src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component.spec.ts
@@ -17,15 +17,15 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { OffCampusRecordDetailComponent } from './off-campus-record-detail.component';
 import { ReviewNoteService } from 'src/app/data-management/services/review-note.service';
-import { ReviewNoteResponse } from 'src/app/shared/interfaces/review-note';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { ReviewNote } from 'src/app/shared/interfaces/review-note';
+import { Record } from 'src/app/shared/interfaces/record';
 import { Location } from '@angular/common';
 
 describe('OffCampusRecordDetailComponent', () => {
   let component: OffCampusRecordDetailComponent;
   let fixture: ComponentFixture<OffCampusRecordDetailComponent>;
   let getReviewNotes$: jasmine.Spy;
-  let createReviewNote$: Subject<ReviewNoteResponse>;
+  let createReviewNote$: Subject<ReviewNote>;
   let snackBarOpen: jasmine.Spy;
 
   beforeEach(async(() => {
@@ -58,20 +58,11 @@ describe('OffCampusRecordDetailComponent', () => {
               create_time: '2019-01-01',
               update_time: '2019-01-02',
               campus_event: null,
-              off_campus_event: {id: 1,
-                                 create_time: '2019-03-02T09:07:57.159755+08:00',
-                                 update_time: '2019-03-02T09:07:57.159921+08:00',
-                                 name: 'sfdg',
-                                 time: '2019-03-02T00:00:00+08:00',
-                                 location: 'dfgfd',
-                                 num_hours: 0,
-                                 num_participants: 25
-                                 },
               contents: [],
               attachments: [],
               user: 1,
               status: 1,
-            } as RecordResponse}),
+            } as Record}),
           }
         },
         {

--- a/src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component.ts
+++ b/src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component.ts
@@ -4,9 +4,9 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material';
 import { HttpErrorResponse } from '@angular/common/http';
 
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { ReviewNoteService } from 'src/app/data-management/services/review-note.service';
-import { ReviewNoteResponse } from 'src/app/shared/interfaces/review-note';
+import { ReviewNote } from 'src/app/shared/interfaces/review-note';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
 
 @Component({
@@ -14,9 +14,9 @@ import { GenericListComponent } from 'src/app/shared/generics/generic-list/gener
   templateUrl: './off-campus-record-detail.component.html',
   styleUrls: ['./off-campus-record-detail.component.css']
 })
-export class OffCampusRecordDetailComponent extends GenericListComponent<ReviewNoteResponse> implements OnInit {
+export class OffCampusRecordDetailComponent extends GenericListComponent<ReviewNote> implements OnInit {
   /** The data to be displayed. */
-  @Input() record: RecordResponse;
+  @Input() record: Record;
   reviewnotecontent: string;
 
   constructor(
@@ -55,7 +55,7 @@ export class OffCampusRecordDetailComponent extends GenericListComponent<ReviewN
   }
 
   ngOnInit() {
-    this.route.data.subscribe((data: { record: RecordResponse}) => {
+    this.route.data.subscribe((data: { record: Record}) => {
       this.record = data.record;
     });
     super.ngOnInit();

--- a/src/app/shared/generics/generic-list/generic-list.spec.ts
+++ b/src/app/shared/generics/generic-list/generic-list.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GenericListComponent } from './generic-list';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
-import { GenericObject } from 'src/app/shared/interfaces/generics';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Component } from '@angular/core';
 import { HAMMER_LOADER } from '@angular/platform-browser';
@@ -14,7 +13,7 @@ import { MatPaginatorModule } from '@angular/material';
     selector: 'app-list-component',
     template: '<mat-paginator></mat-paginator>',
 })
-class ListComponent extends GenericListComponent<GenericObject> {
+class ListComponent extends GenericListComponent<{id: number}> {
     constructor(
         protected readonly route: ActivatedRoute,
         protected readonly router: Router,
@@ -24,7 +23,7 @@ class ListComponent extends GenericListComponent<GenericObject> {
     }
 
     getResults(offset: number, limit: number) {
-        return observableOf({} as PaginatedResponse<GenericObject>);
+        return observableOf({} as PaginatedResponse<{id: number}>);
     }
 }
 
@@ -33,7 +32,7 @@ describe('GenericListComponent', () => {
     let fixture: ComponentFixture<ListComponent>;
     let navigate: jasmine.Spy;
     let getResults: jasmine.Spy;
-    let getResults$: Subject<PaginatedResponse<GenericObject>>;
+    let getResults$: Subject<PaginatedResponse<{id: number}>>;
     let go: jasmine.Spy;
     const dummyResponse = { id: 1 };
 

--- a/src/app/shared/generics/generic-list/generic-list.ts
+++ b/src/app/shared/generics/generic-list/generic-list.ts
@@ -7,11 +7,10 @@ import { switchMap, map, catchError, startWith } from 'rxjs/operators';
 
 import { environment } from 'src/environments/environment';
 import { PaginatedResponse } from '../../interfaces/paginated-response';
-import { GenericObject } from '../../interfaces/generics';
 
 
 /** Implement generic logic for displaying list of objects. */
-export abstract class GenericListComponent<T extends GenericObject> implements OnInit {
+export abstract class GenericListComponent<T extends {id?: number}> implements OnInit {
   /** The data to be displayed */
   results: T[] = [];
   /** The total number of results. */

--- a/src/app/shared/interfaces/auth-service.ts
+++ b/src/app/shared/interfaces/auth-service.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 import { InjectionToken } from '@angular/core';
+import { User } from './user';
 
 
 /** This interface declares required methods for an authentication service. */
@@ -50,23 +51,6 @@ export interface AuthService {
     refreshJWT(): Observable<boolean>;
     /** Remove all JWT information. */
     removeJWT();
-}
-
-export interface User {
-    id: number;
-    username: string;
-    last_login: string;
-    first_name: string;
-    last_name: string;
-    email: string;
-    is_active: boolean;
-    date_joined: string;
-    user_permissions: number[];
-    is_teacher: boolean;
-    is_department_admin: boolean;
-    is_school_admin: boolean;
-    department: number;
-    department_str?: string;
 }
 
 /** RESTful response interface for JWT auth. */

--- a/src/app/shared/interfaces/campus-event-feedback.ts
+++ b/src/app/shared/interfaces/campus-event-feedback.ts
@@ -1,0 +1,7 @@
+export interface CampusEventFeedback {
+  id?: number;
+  create_time?: string;
+  update_time?: string;
+  record?: number;
+  feedback?: string;
+}

--- a/src/app/shared/interfaces/department.ts
+++ b/src/app/shared/interfaces/department.ts
@@ -1,6 +1,4 @@
-import { GenericObject } from './generics';
-
-export interface Department extends GenericObject {
+export interface Department {
     id?: number;
     name?: string;
     create_time?: string;

--- a/src/app/shared/interfaces/event.ts
+++ b/src/app/shared/interfaces/event.ts
@@ -1,5 +1,5 @@
 interface Event {
-  id?: number
+  id?: number;
   create_time?: string;
   update_time?: string;
   name?: string;

--- a/src/app/shared/interfaces/event.ts
+++ b/src/app/shared/interfaces/event.ts
@@ -1,43 +1,21 @@
-import { Program } from './program';
 interface Event {
-  name: string;
-  time: string;
-  location: string;
+  id?: number
   create_time?: string;
   update_time?: string;
-  num_hours: number;
-  num_participants: number;
+  name?: string;
+  time?: string;
+  location?: string;
+  num_hours?: number;
+  num_participants?: number;
 }
 
 // tslint:disable-next-line:no-empty-interface
-interface OffCampusEvent extends Event {
+export interface OffCampusEvent extends Event {
 }
 
-interface CampusEvent extends Event {
+export interface CampusEvent extends Event {
+  program?: number;
+  deadline?: string;
   num_enrolled?: number;
-  deadline: string;
-  description: string;
-}
-
-/** RESTful request interface for CampusEvent. */
-// tslint:disable-next-line:no-empty-interface
-export interface CampusEventRequest extends CampusEvent {
-  program: number;
-}
-
-/** RESTful response interface for CampusEvent. */
-export interface CampusEventResponse extends CampusEvent {
-  id: number;
-  program: number;
-  program_detail: Program;
-}
-
-/** RESTful request interface for OffCampusEvent. */
-// tslint:disable-next-line:no-empty-interface
-export interface OffCampusEventRequest extends OffCampusEvent {
-}
-
-/** RESTful response interface for OffCampusEvent. */
-export interface OffCampusEventResponse extends OffCampusEvent {
-  id: number;
+  description?: string;
 }

--- a/src/app/shared/interfaces/generics.ts
+++ b/src/app/shared/interfaces/generics.ts
@@ -1,4 +1,0 @@
-/** Generic type for an object. */
-export interface GenericObject {
-    id?: number;
-}

--- a/src/app/shared/interfaces/notification.ts
+++ b/src/app/shared/interfaces/notification.ts
@@ -1,9 +1,9 @@
 /** RESTful response interface for Notification. */
-export interface NotificationResponse {
-  id: number;
-  time: string;
-  sender: string;
-  recipient: string;
-  content: string;
-  read_time: string;
+export interface Notification {
+  id?: number;
+  time?: string;
+  sender?: number;
+  recipient?: number;
+  content?: string;
+  read_time?: string;
 }

--- a/src/app/shared/interfaces/permission.ts
+++ b/src/app/shared/interfaces/permission.ts
@@ -1,11 +1,11 @@
 /** Permission objects are basic items to check permissions. */
 export interface Permission {
     /** The id of the permission. */
-    id: number;
+    id?: number;
     /** Human-readable label of thie permission. */
-    label: string;
+    label?: string;
     /** The codename of the permission. */
-    codename: string;
+    codename?: string;
 }
 
 /** UserPermission objects are related to specific user. */
@@ -13,23 +13,18 @@ export interface UserPermission {
     /** The id of the user-permission. */
     id?: number;
     /** The id of the user. */
-    user: number;
+    user?: number;
     /** The id of the permission. */
-    permission: number;
+    permission?: number;
 }
 
-export interface UserPermissionRequest {
-    user: number;
-    permission: number;
-}
-
-/** The status of user for specific permission */
+/** The status of user for specific permission, it's temporary object. */
 export interface UserPermissionStatus {
     /** The id of the user-permission. */
     id?: number;
     /** The id of the user. */
-    user: number;
+    user?: number;
     /** The permission object. */
-    permission: Permission;
-    hasPermission: boolean;
+    permission?: Permission;
+    hasPermission?: boolean;
 }

--- a/src/app/shared/interfaces/program-category.ts
+++ b/src/app/shared/interfaces/program-category.ts
@@ -1,4 +1,4 @@
 export interface ProgramCategory {
-    id: number;
-    name: string;
+    id?: number;
+    name?: string;
 }

--- a/src/app/shared/interfaces/program-form.ts
+++ b/src/app/shared/interfaces/program-form.ts
@@ -1,4 +1,4 @@
 export interface ProgramForm {
-    id: number;
-    name: string;
+    id?: number;
+    name?: string;
 }

--- a/src/app/shared/interfaces/program.ts
+++ b/src/app/shared/interfaces/program.ts
@@ -1,17 +1,7 @@
-import { Department } from './department';
-import { ProgramCategory } from './program-category';
 export interface Program {
-    id: number;
-    department: number;
-    category: number;
-    department_detail: Department;
-    category_detail: ProgramCategory;
-    form: number[];
-    name: string;
-}
-export interface ProgramRequest {
-    department: number;
-    category: number;
-    name: string;
-    form: number[];
+    id?: number;
+    name?: string;
+    department?: number;
+    category?: number;
+    form?: number[];
 }

--- a/src/app/shared/interfaces/record-attachment.ts
+++ b/src/app/shared/interfaces/record-attachment.ts
@@ -1,0 +1,12 @@
+import { AttachmentType } from '../enums/attachment-type.enum';
+
+/** RESTful request interface for RecordAttachment. */
+export interface RecordAttachment {
+  id?: number;
+  create_time?: string;
+  update_time?: string;
+  record?: number;
+  attachment_type?: AttachmentType;
+  path?: File | string;
+}
+

--- a/src/app/shared/interfaces/record-content.ts
+++ b/src/app/shared/interfaces/record-content.ts
@@ -1,0 +1,14 @@
+import { ContentType } from '../enums/content-type.enum';
+
+/** Interface for RecordContent. */
+export interface RecordContent {
+  id?: number;
+  create_time?: string;
+  update_time?: string;
+  record?: number;
+  /** The type of this content. */
+  content_type?: ContentType;
+  /** The value of thie content. */
+  content?: string;
+}
+

--- a/src/app/shared/interfaces/record.ts
+++ b/src/app/shared/interfaces/record.ts
@@ -1,70 +1,15 @@
-import { RecordStatus } from '../enums/record-status.enum';
-import { ContentType } from '../enums/content-type.enum';
-import { AttachmentType } from '../enums/attachment-type.enum';
-import { OffCampusEventRequest, CampusEventResponse, OffCampusEventResponse } from './event';
-
-/** RESTful request interface for Record. */
-export interface RecordRequest {
-  off_campus_event: OffCampusEventRequest;
-  user: number;
-  contents: RecordContent[];
-  attachments: File[];
-}
+import { RecordContent } from './record-content';
 
 /** RESTful reponse interface for Record. */
-export interface RecordResponse {
-  id: number;
-  create_time: string;
-  update_time: string;
-  campus_event: CampusEventResponse | null;
-  off_campus_event: OffCampusEventResponse | null;
-  attachments: RecordAttachmentResponse[];
-  contents: RecordContentResponse[];
-  user: number;
-  status: RecordStatus;
-  feedback?: CampusEventFeedbackReponse[];
-}
-
-/** Interface for RecordContent. */
-export interface RecordContent {
-  /** The type of this content. */
-  content_type: ContentType;
-  /** The value of thie content. */
-  content: string;
-}
-
-/** RESTful request interface for RecordContent. */
-export interface RecordContentRequest extends RecordContent {
-  record: number;
-}
-
-/** RESTful response interface for RecordContent. */
-export interface RecordContentResponse extends RecordContent {
-  id: number;
-  record: number;
-  create_time: string;
-  update_time: string;
-}
-
-/** RESTful request interface for RecordAttachment. */
-export interface RecordAttachmentRequest {
-  record: number;
-  attachment_type?: AttachmentType;
-  path: File;
-}
-
-/** RESTful response interface for RecordAttachment. */
-export interface RecordAttachmentResponse {
-  id: number;
-  create_time: string;
-  update_time: string;
-  record: number;
-  attachment_type: AttachmentType;
-  path: string;
-}
-
-export interface CampusEventFeedbackReponse {
-  record: number;
-  feedback: string;
-  create_time: string;
+export interface Record {
+  id?: number;
+  create_time?: string;
+  update_time?: string;
+  campus_event?: number;
+  off_campus_event?: number;
+  user?: number;
+  status?: number;
+  feedback?: number;
+  attachments?: number[] | File[];
+  contents?: number[] | RecordContent[];
 }

--- a/src/app/shared/interfaces/review-note.ts
+++ b/src/app/shared/interfaces/review-note.ts
@@ -1,15 +1,8 @@
-/** RESTful request interface for Review-Note. */
-export interface ReviewNoteRequest {
-  content: string;
-  record: number;
-  user: number;
-}
-
 /** RESTful reponse interface for Review-Note. */
-export interface ReviewNoteResponse {
-  id: number;
-  create_time: string;
-  content: string;
-  record: number;
-  user: number;
+export interface ReviewNote {
+  id?: number;
+  create_time?: string;
+  record?: number;
+  user?: number;
+  content?: string;
 }

--- a/src/app/shared/interfaces/route-info.ts
+++ b/src/app/shared/interfaces/route-info.ts
@@ -1,3 +1,4 @@
+/** FE-only, this interface is used to define items in sidebar menu. */
 export interface RouteInfo {
     path: string;
     title: string;

--- a/src/app/shared/interfaces/user.ts
+++ b/src/app/shared/interfaces/user.ts
@@ -1,0 +1,16 @@
+export interface User {
+    id?: number;
+    username?: string;
+    last_login?: string;
+    first_name?: string;
+    last_name?: string;
+    email?: string;
+    is_active?: boolean;
+    date_joined?: string;
+    user_permissions?: number[];
+    is_teacher?: boolean;
+    is_department_admin?: boolean;
+    is_school_admin?: boolean;
+    department?: number;
+    department_str?: string;
+}

--- a/src/app/shared/services/notification.service.spec.ts
+++ b/src/app/shared/services/notification.service.spec.ts
@@ -4,22 +4,22 @@ import { of as observableOf, throwError, Subject } from 'rxjs';
 
 import { NotificationService } from './notification.service';
 import { environment } from 'src/environments/environment';
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
 
 describe('NotificationService', () => {
   let httpTestingController: HttpTestingController;
-  const dummyNotification: NotificationResponse = {
+  const dummyNotification: Notification = {
     id: 1,
     time: '2019-01-01',
-    sender: 'sender',
-    recipient: 'recipient',
+    sender: 4,
+    recipient: 5,
     content: 'content',
     read_time: '2019-01-01',
   };
 
-  const dummyResponse: PaginatedResponse<NotificationResponse> = {
+  const dummyResponse: PaginatedResponse<Notification> = {
     count: 100,
     next: 'next',
     previous: 'previous',

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -4,7 +4,7 @@ import { switchMap, map, catchError, takeWhile } from 'rxjs/operators';
 import { HttpClient } from '@angular/common/http';
 
 import { environment } from 'src/environments/environment';
-import { NotificationResponse } from 'src/app/shared/interfaces/notification';
+import { Notification } from 'src/app/shared/interfaces/notification';
 import { AUTH_SERVICE, AuthService } from 'src/app/shared/interfaces/auth-service';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
@@ -15,7 +15,7 @@ import { ListRequest } from 'src/app/shared/interfaces/list-request';
 })
 export class NotificationService extends GenericListService {
   /** Latest unread notifications. */
-  unreadNotifications: NotificationResponse[] = [];
+  unreadNotifications: Notification[] = [];
   /** Indicate whether unread notifications has been loaded. */
   unreadNotificationsLoaded = false;
 
@@ -41,23 +41,23 @@ export class NotificationService extends GenericListService {
   }
 
   getNotification(id: number) {
-    return this.http.get<NotificationResponse>(
+    return this.http.get<Notification>(
       `${environment.API_URL}/notifications/${id}/`);
   }
 
   /** API for retrieving notifications. */
   getNotifications(req: ListRequest) {
-    return this.list<NotificationResponse>('notifications', req);
+    return this.list<Notification>('notifications', req);
   }
 
   /** API for retrieving notifications which have been read. */
   getReadNotifications(req: ListRequest) {
-    return this.list<NotificationResponse>('notifications/read', req);
+    return this.list<Notification>('notifications/read', req);
   }
 
   /** API for retrieving notifications which haven't been read. */
   getUnReadNotifications(req: ListRequest) {
-    return this.list<NotificationResponse>('notifications/unread', req);
+    return this.list<Notification>('notifications/unread', req);
   }
 
   /** Mark all notifications for user as read. */

--- a/src/app/shared/services/permission.service.ts
+++ b/src/app/shared/services/permission.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, zip, of as observableOf } from 'rxjs';
-import { Permission, UserPermission, UserPermissionRequest } from '../interfaces/permission';
+import { Permission, UserPermission } from '../interfaces/permission';
 import { HttpClient } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
 import { tap } from 'rxjs/operators';
@@ -35,11 +35,11 @@ export class PermissionService {
       `${environment.API_URL}/user-permissions/?user=${userId}`);
   }
 
-  createUserPermission(req: UserPermissionRequest) {
+  createUserPermission(req: UserPermission) {
     return this.http.post(`${environment.API_URL}/user-permissions/`, req);
   }
 
-  createUserPermissions(reqs: UserPermissionRequest[]) {
+  createUserPermissions(reqs: UserPermission[]) {
     // TODO(youchen): Evaluate the performance cost.
     if (reqs.length === 0) return observableOf([]);
     return zip(...reqs.map(req => this.createUserPermission(req)));

--- a/src/app/shared/services/user.service.ts
+++ b/src/app/shared/services/user.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
-import { User } from '../interfaces/auth-service';
+import { User } from '../interfaces/user';
 import { PaginatedResponse } from '../interfaces/paginated-response';
 
 /** This service manage User objects. */

--- a/src/app/statistics/components/data-export/data-export.component.spec.ts
+++ b/src/app/statistics/components/data-export/data-export.component.spec.ts
@@ -18,14 +18,14 @@ import { HAMMER_LOADER } from '@angular/platform-browser';
 import { Location } from '@angular/common';
 import { RecordService } from 'src/app/training-record/services/record.service';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { Subject } from 'rxjs';
 
 describe('DataExportComponent', () => {
   let component: DataExportComponent;
   let fixture: ComponentFixture<DataExportComponent>;
   let getRecords: jasmine.Spy;
-  let getRecords$: Subject<PaginatedResponse<RecordResponse>>;
+  let getRecords$: Subject<PaginatedResponse<Record>>;
 
   beforeEach(async(() => {
     getRecords$ = new Subject();

--- a/src/app/statistics/components/data-export/data-export.component.ts
+++ b/src/app/statistics/components/data-export/data-export.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Location } from '@angular/common';
 import { RecordService } from 'src/app/training-record/services/record.service';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder } from '@angular/forms';
 
@@ -11,7 +11,7 @@ import { FormBuilder } from '@angular/forms';
   templateUrl: './data-export.component.html',
   styleUrls: ['./data-export.component.css']
 })
-export class DataExportComponent extends GenericListComponent<RecordResponse> {
+export class DataExportComponent extends GenericListComponent<Record> {
   /** Use FormBuilder to build our form to collect Record data. */
   filterForm = this.fb.group({
     eventName: [''],

--- a/src/app/training-event/components/admin-campus-event-detail/admin-campus-event-detail.component.html
+++ b/src/app/training-event/components/admin-campus-event-detail/admin-campus-event-detail.component.html
@@ -85,7 +85,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">项目名称</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ item.program_detail.name }}</p>
+                  <!-- <p>{{ item.program_detail.name }}</p> -->
                 </div>
               <div fxFlex="1 0 2%"></div>
             </div>   
@@ -93,7 +93,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">项目单位</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ item.program_detail.department_detail.name }}</p>
+                  <!-- <p>{{ item.program_detail.department_detail.name }}</p> -->
                 </div>
               <div fxFlex="1 0 2%"></div>
             </div>   
@@ -101,7 +101,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">项目类别</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ item.program_detail.category_detail.name }}</p>
+                  <!-- <p>{{ item.program_detail.category_detail.name }}</p> -->
                 </div>
                 <div fxFlex="1 0 2%"></div>
               </div>

--- a/src/app/training-event/components/admin-campus-event-detail/admin-campus-event-detail.component.spec.ts
+++ b/src/app/training-event/components/admin-campus-event-detail/admin-campus-event-detail.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { of as observableOf } from 'rxjs';
 import { AdminCampusEventDetailComponent } from './admin-campus-event-detail.component';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
 
@@ -63,7 +63,7 @@ describe('AddminCampusEventDetailComponent', () => {
                 num_enrolled: 0,
                 description: '问题解决建设不同.所以任何下.',
                 program: 157
-              } as CampusEventResponse}),
+              } as CampusEvent}),
           }
         }
       ]

--- a/src/app/training-event/components/admin-campus-event-detail/admin-campus-event-detail.component.ts
+++ b/src/app/training-event/components/admin-campus-event-detail/admin-campus-event-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 
 
 @Component({
@@ -11,7 +11,7 @@ import { CampusEventResponse } from 'src/app/shared/interfaces/event';
 })
 export class AdminCampusEventDetailComponent implements OnInit {
 
-  item: CampusEventResponse;
+  item: CampusEvent;
 
   constructor(
     readonly location: Location,
@@ -20,7 +20,7 @@ export class AdminCampusEventDetailComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.route.data.subscribe((data: { item: CampusEventResponse}) => {
+    this.route.data.subscribe((data: { item: CampusEvent}) => {
       this.item = data.item;
     });
   }

--- a/src/app/training-event/components/admin-campus-event-list/admin-campus-event-list.component.spec.ts
+++ b/src/app/training-event/components/admin-campus-event-list/admin-campus-event-list.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatProgressSpinnerModule, MatPaginatorModule, MatIconModule } from '@angular/material';
 import { Router, ActivatedRoute } from '@angular/router';
 import { of as observableOf, Subject  } from 'rxjs';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { Program } from 'src/app/shared/interfaces/program';
 import { ProgramService } from '../../../training-program/services/program.service';
 import { EventService } from '../../services/event.service';
@@ -14,7 +14,7 @@ import { Location } from '@angular/common';
 describe('AdminCampusEventListComponent', () => {
   let component: AdminCampusEventListComponent;
   let fixture: ComponentFixture<AdminCampusEventListComponent>;
-  let getCampusEvents$: Subject<PaginatedResponse<CampusEventResponse>>;
+  let getCampusEvents$: Subject<PaginatedResponse<CampusEvent>>;
   let getCampusEvents: jasmine.Spy;
   let getProgram$: Subject<Program>;
   let getProgram: jasmine.Spy;
@@ -25,23 +25,12 @@ describe('AdminCampusEventListComponent', () => {
     name: 'sender',
     department: 2,
     category: 3,
-    department_detail: {
-      id: 2,
-      create_time: '2019-3-4',
-      update_time: '2019-3-6',
-      name: 'test',
-      admins: [],
-    },
-    category_detail: {
-      id: 3,
-      name: 'test',
-    },
     form: [],
   };
 
   beforeEach(async(() => {
     navigate = jasmine.createSpy();
-    getCampusEvents$ = new Subject<PaginatedResponse<CampusEventResponse>>();
+    getCampusEvents$ = new Subject<PaginatedResponse<CampusEvent>>();
     getCampusEvents = jasmine.createSpy();
     getCampusEvents.and.returnValue(getCampusEvents$);
     getProgram$ = new Subject<Program>();

--- a/src/app/training-event/components/admin-campus-event-list/admin-campus-event-list.component.ts
+++ b/src/app/training-event/components/admin-campus-event-list/admin-campus-event-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { EventService  } from '../../services/event.service';
 import { ProgramService } from '../../../training-program/services/program.service';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -14,7 +14,7 @@ import { switchMap } from 'rxjs/operators';
   styleUrls: ['./admin-campus-event-list.component.css']
 })
 
-export class AdminCampusEventListComponent extends GenericListComponent<CampusEventResponse> implements OnInit {
+export class AdminCampusEventListComponent extends GenericListComponent<CampusEvent> implements OnInit {
 
   programId: number;
   program: Program;

--- a/src/app/training-event/components/admin-campus-form/admin-campus-form.component.spec.ts
+++ b/src/app/training-event/components/admin-campus-form/admin-campus-form.component.spec.ts
@@ -15,13 +15,13 @@ import { Router, ActivatedRoute } from '@angular/router';
 
 import { AdminCampusFormComponent } from './admin-campus-form.component';
 import { HttpErrorResponse } from '@angular/common/http';
-import { CampusEventRequest } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { EventService } from '../../services/event.service';
 
 describe('AdminCampusFormComponent', () => {
   let component: AdminCampusFormComponent;
   let fixture: ComponentFixture<AdminCampusFormComponent>;
-  let createEventForm$: Subject<CampusEventRequest>;
+  let createEventForm$: Subject<CampusEvent>;
   let navigate: jasmine.Spy;
   let snackBarOpen: jasmine.Spy;
 
@@ -87,7 +87,7 @@ describe('AdminCampusFormComponent', () => {
 
   it('should navigate when creation succeed.', () => {
     component.onSubmit();
-    createEventForm$.next({ program: 2 } as CampusEventRequest);
+    createEventForm$.next({ program: 2 } as CampusEvent);
 
     expect(navigate).toHaveBeenCalledWith(['../event-detail/', 2]);
   });

--- a/src/app/training-event/components/admin-campus-form/admin-campus-form.component.ts
+++ b/src/app/training-event/components/admin-campus-form/admin-campus-form.component.ts
@@ -4,7 +4,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material';
 
-import { CampusEventRequest } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { EventService } from '../../services/event.service';
 
 @Component({
@@ -67,7 +67,7 @@ export class AdminCampusFormComponent implements OnInit {
     return this.eventForm.get('description');
   }
   onSubmit() {
-    const req: CampusEventRequest = {
+    const req: CampusEvent = {
       program: this.programId,
       name: this.eventForm.value.name,
       time: this.eventForm.value.time,

--- a/src/app/training-event/components/campus-event-detail/campus-event-detail.component.html
+++ b/src/app/training-event/components/campus-event-detail/campus-event-detail.component.html
@@ -85,7 +85,7 @@
             fxLayoutGap="15px">
               <span class="item-title" fxFlex="1 0 20%">项目名称</span>
               <div class="item-content" fxFlex="1 0 78%">
-                <p>{{ item.program_detail.name }}</p>
+                <!-- <p>{{ item.program_detail.name }}</p> -->
               </div>
             <div fxFlex="1 0 2%"></div>
           </div>   
@@ -93,7 +93,7 @@
             fxLayoutGap="15px">
               <span class="item-title" fxFlex="1 0 20%">项目单位</span>
               <div class="item-content" fxFlex="1 0 78%">
-                <p>{{ item.program_detail.department_detail.name }}</p>
+                <!-- <p>{{ item.program_detail.department_detail.name }}</p> -->
               </div>
             <div fxFlex="1 0 2%"></div>
           </div>   
@@ -101,7 +101,7 @@
             fxLayoutGap="15px">
               <span class="item-title" fxFlex="1 0 20%">项目类别</span>
               <div class="item-content" fxFlex="1 0 78%">
-                <p>{{ item.program_detail.category_detail.name }}</p>
+                <!-- <p>{{ item.program_detail.category_detail.name }}</p> -->
               </div>
             <div fxFlex="1 0 2%"></div>
           </div>

--- a/src/app/training-event/components/campus-event-detail/campus-event-detail.component.spec.ts
+++ b/src/app/training-event/components/campus-event-detail/campus-event-detail.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { of as observableOf } from 'rxjs';
 import { CampusEventDetailComponent } from './campus-event-detail.component';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 
@@ -55,7 +55,7 @@ describe('CampusEventDetailComponent', () => {
                 num_enrolled: 0,
                 description: '问题解决建设不同.所以任何下.',
                 program: 157
-              } as CampusEventResponse}),
+              } as CampusEvent}),
           }
         }
       ]

--- a/src/app/training-event/components/campus-event-detail/campus-event-detail.component.ts
+++ b/src/app/training-event/components/campus-event-detail/campus-event-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 
 @Component({
   selector: 'app-campus-event-detail',
@@ -10,7 +10,7 @@ import { CampusEventResponse } from 'src/app/shared/interfaces/event';
 })
 export class CampusEventDetailComponent implements OnInit {
 
-  item: CampusEventResponse;
+  item: CampusEvent;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -18,7 +18,7 @@ export class CampusEventDetailComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.route.data.subscribe((data: { item: CampusEventResponse}) => {
+    this.route.data.subscribe((data: { item: CampusEvent}) => {
       this.item = data.item;
     });
   }

--- a/src/app/training-event/components/campus-event-list/campus-event-list.component.spec.ts
+++ b/src/app/training-event/components/campus-event-list/campus-event-list.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatProgressSpinnerModule, MatPaginatorModule, MatIconModule } from '@angular/material';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { EventService } from '../../services/event.service';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
 import { HAMMER_LOADER } from '@angular/platform-browser';
@@ -12,13 +12,13 @@ import { Location } from '@angular/common';
 describe('CampusEventListComponent', () => {
   let component: CampusEventListComponent;
   let fixture: ComponentFixture<CampusEventListComponent>;
-  let getCampusEvents$: Subject<PaginatedResponse<CampusEventResponse>>;
+  let getCampusEvents$: Subject<PaginatedResponse<CampusEvent>>;
   let getCampusEvents: jasmine.Spy;
   let navigate: jasmine.Spy;
 
   beforeEach(async(() => {
     navigate = jasmine.createSpy();
-    getCampusEvents$ = new Subject<PaginatedResponse<CampusEventResponse>>();
+    getCampusEvents$ = new Subject<PaginatedResponse<CampusEvent>>();
     getCampusEvents = jasmine.createSpy();
     getCampusEvents.and.returnValue(getCampusEvents$);
     TestBed.configureTestingModule({

--- a/src/app/training-event/components/campus-event-list/campus-event-list.component.ts
+++ b/src/app/training-event/components/campus-event-list/campus-event-list.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Location } from '@angular/common';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 import { EventService  } from '../../services/event.service';
 import { Router, ActivatedRoute } from '@angular/router';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
@@ -11,7 +11,7 @@ import { GenericListComponent } from 'src/app/shared/generics/generic-list/gener
   templateUrl: './campus-event-list.component.html',
   styleUrls: ['./campus-event-list.component.css']
 })
-export class CampusEventListComponent extends GenericListComponent<CampusEventResponse> {
+export class CampusEventListComponent extends GenericListComponent<CampusEvent> {
   constructor(
     private readonly eventService: EventService,
     protected readonly route: ActivatedRoute,

--- a/src/app/training-event/services/event-detail-resolver.service.ts
+++ b/src/app/training-event/services/event-detail-resolver.service.ts
@@ -3,18 +3,18 @@ import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/r
 import { Observable } from 'rxjs';
 
 import { EventService } from './event.service';
-import { CampusEventResponse } from 'src/app/shared/interfaces/event';
+import { CampusEvent } from 'src/app/shared/interfaces/event';
 /** Pre-fetching notification data. */
 @Injectable({
   providedIn: 'root'
 })
-export class EventDetailResolverService implements Resolve<CampusEventResponse> {
+export class EventDetailResolverService implements Resolve<CampusEvent> {
 
   constructor(
     private readonly eventService: EventService,
   ) { }
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CampusEventResponse > {
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CampusEvent > {
     const id = +route.paramMap.get('id');
     return this.eventService.getEvent(id);
   }

--- a/src/app/training-event/services/event.service.spec.ts
+++ b/src/app/training-event/services/event.service.spec.ts
@@ -5,9 +5,8 @@ import { Subject } from 'rxjs';
 import { EventService } from './event.service';
 import { environment } from 'src/environments/environment';
 import {
-  OffCampusEventRequest,
-  OffCampusEventResponse,
-  CampusEventRequest,
+  OffCampusEvent,
+  CampusEvent,
 } from 'src/app/shared/interfaces/event';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 
@@ -89,7 +88,7 @@ describe('EventService', () => {
       location: 'location',
       num_hours: 10,
       num_participants: 50,
-    } as OffCampusEventRequest).subscribe();
+    } as OffCampusEvent).subscribe();
     const req = httpTestingController.expectOne(
       `${environment.API_URL}/off-campus-events/`);
     expect(req.request.method).toEqual('POST');
@@ -99,7 +98,7 @@ describe('EventService', () => {
       location: 'location',
       num_hours: 10,
       num_participants: 50,
-    } as OffCampusEventResponse);
+    } as OffCampusEvent);
   });
 
   it('should delete OffCampusEvent', () => {
@@ -116,7 +115,7 @@ describe('EventService', () => {
   it('should create event-form', () => {
     const service: EventService = TestBed.get(EventService);
 
-    const createReq: CampusEventRequest = {
+    const createReq: CampusEvent = {
       name: 'test',
       time: 'time',
       location: 'location',

--- a/src/app/training-event/services/event.service.ts
+++ b/src/app/training-event/services/event.service.ts
@@ -3,10 +3,8 @@ import { HttpClient } from '@angular/common/http';
 
 import { environment } from 'src/environments/environment';
 import {
-  CampusEventResponse,
-  OffCampusEventRequest,
-  OffCampusEventResponse,
-  CampusEventRequest,
+  OffCampusEvent,
+  CampusEvent,
 } from 'src/app/shared/interfaces/event';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
@@ -24,19 +22,19 @@ export class EventService extends GenericListService {
   }
 
   getEvent(id: number) {
-    return this.http.get<CampusEventResponse>(
+    return this.http.get<CampusEvent>(
       `${environment.API_URL}/campus-events/${id}/`);
   }
 
   /** Retrieve campus events. */
   /** TODO(youchen): Rename this function */
   getCampusEvents(req: ListRequest) {
-    return this.list<CampusEventResponse>('campus-events', req);
+    return this.list<CampusEvent>('campus-events', req);
   }
 
   /** Create an off-campus event. */
-  createOffCampusEvent(req: OffCampusEventRequest) {
-    return this.http.post<OffCampusEventResponse>(
+  createOffCampusEvent(req: OffCampusEvent) {
+    return this.http.post<OffCampusEvent>(
       `${environment.API_URL}/off-campus-events/`, req);
   }
 
@@ -48,12 +46,12 @@ export class EventService extends GenericListService {
 
   /** Retrieve off-campus events, it's frequently used in AutoComplete. */
   getOffCampusEvents(req: ListRequest) {
-    return this.list<OffCampusEventResponse>('off-campus-events', req);
+    return this.list<OffCampusEvent>('off-campus-events', req);
   }
 
   /**  Admin create campus event */
-  createCampusEvent(req: CampusEventRequest) {
-    return this.http.post<CampusEventResponse>(
+  createCampusEvent(req: CampusEvent) {
+    return this.http.post<CampusEvent>(
       `${environment.API_URL}/campus-events/`, req);
   }
 

--- a/src/app/training-program/components/program-detail/program-detail.component.html
+++ b/src/app/training-program/components/program-detail/program-detail.component.html
@@ -20,7 +20,7 @@
               fxLayoutGap="15px">
               <span class="item-title" fxFlex="1 0 20%">所属院系</span>
               <div class="item-content" fxFlex="1 0 78%">
-                <p>{{ program.department_detail.name }}</p>
+                <!-- <p>{{ program.department_detail.name }}</p> -->
               </div>
               <div fxFlex="1 0 2%"></div>
             </div>
@@ -29,7 +29,7 @@
               fxLayoutGap="15px">
               <span class="item-title" fxFlex="1 0 20%">培训类别</span>
               <div class="item-content" fxFlex="1 0 78%">
-                <p>{{ program.category_detail.name }}</p>
+                <!-- <p>{{ program.category_detail.name }}</p> -->
               </div>
               <div fxFlex="1 0 2%"></div>
             </div>

--- a/src/app/training-program/components/program-form/program-form.component.spec.ts
+++ b/src/app/training-program/components/program-form/program-form.component.spec.ts
@@ -158,18 +158,6 @@ describe('ProgramFormComponent', () => {
       name: 'sender',
       department: 2,
       category: 3,
-      department_detail: {
-        id: 2,
-        create_time: '2019-3-4',
-        update_time: '2019-3-6',
-        name: 'test',
-        admins: [],
-      },
-      category_detail: {
-        id: 3,
-        name: 'test',
-      },
-      form: [],
     };
     getProgram$.next(dummyProgram);
 

--- a/src/app/training-program/components/program-form/program-form.component.ts
+++ b/src/app/training-program/components/program-form/program-form.component.ts
@@ -5,10 +5,9 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material';
 import { map } from 'rxjs/operators';
 
-import { ProgramRequest } from 'src/app/shared/interfaces/program';
+import { Program } from 'src/app/shared/interfaces/program';
 import { ProgramCategory } from 'src/app/shared/interfaces/program-category';
 import { ProgramForm } from 'src/app/shared/interfaces/program-form';
-import { Program } from 'src/app/shared/interfaces/program';
 import { ProgramService} from '../../services/program.service';
 import { ProgramFormService} from '../../services/program-form.service';
 import { ProgramCategoryService} from '../../services/program-category.service';
@@ -84,7 +83,7 @@ export class ProgramFormComponent implements OnInit {
   }
 
   onSubmit() {
-    const req: ProgramRequest = {
+    const req: Program = {
       department: this.authService.department,
       category: this.programForm.value.categoryId,
       name: this.programForm.value.name,

--- a/src/app/training-program/components/program-list/program-list.component.spec.ts
+++ b/src/app/training-program/components/program-list/program-list.component.spec.ts
@@ -22,18 +22,6 @@ describe('ProgramListComponent', () => {
     name: 'sender',
     department: 2,
     category: 3,
-    department_detail: {
-      id: 2,
-      create_time: '2019-3-4',
-      update_time: '2019-3-6',
-      name: 'test',
-      admins: [],
-    },
-    category_detail: {
-      id: 3,
-      name: 'test',
-    },
-    form: [],
   };
 
   beforeEach(async(() => {

--- a/src/app/training-program/services/program.service.spec.ts
+++ b/src/app/training-program/services/program.service.spec.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs';
 
 import { ProgramService } from './program.service';
 import { environment } from 'src/environments/environment';
-import { ProgramRequest } from 'src/app/shared/interfaces/program';
+import { Program } from 'src/app/shared/interfaces/program';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 
 describe('ProgramService', () => {
@@ -79,7 +79,7 @@ describe('ProgramService', () => {
   it('should create program-form', () => {
     const service: ProgramService = TestBed.get(ProgramService);
 
-    const createReq: ProgramRequest = {
+    const createReq: Program = {
       department: 1,
       name: 'test',
       category: 2,

--- a/src/app/training-program/services/program.service.ts
+++ b/src/app/training-program/services/program.service.ts
@@ -3,7 +3,6 @@ import { HttpClient } from '@angular/common/http';
 
 import { environment } from 'src/environments/environment';
 import { Program } from 'src/app/shared/interfaces/program';
-import { ProgramRequest } from 'src/app/shared/interfaces/program';
 
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
@@ -32,7 +31,7 @@ export class ProgramService extends GenericListService {
   }
 
   /** create program-form. */
-  createProgram(req: ProgramRequest) {
+  createProgram(req: Program) {
     return this.http.post<Program>(
       `${environment.API_URL}/programs/`, req);
   }

--- a/src/app/training-record/components/off-campus-event-record-list/off-campus-event-record-list.component.ts
+++ b/src/app/training-record/components/off-campus-event-record-list/off-campus-event-record-list.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { RecordService } from '../../services/record.service';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
 
@@ -11,7 +11,7 @@ import { GenericListComponent } from 'src/app/shared/generics/generic-list/gener
   templateUrl: './off-campus-event-record-list.component.html',
   styleUrls: ['./off-campus-event-record-list.component.css']
 })
-export class OffCampusEventRecordListComponent extends GenericListComponent<RecordResponse> {
+export class OffCampusEventRecordListComponent extends GenericListComponent<Record> {
 
   constructor(
     protected readonly route: ActivatedRoute,

--- a/src/app/training-record/components/record-detail/record-detail.component.html
+++ b/src/app/training-record/components/record-detail/record-detail.component.html
@@ -17,7 +17,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">项目名称</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ record.campus_event.name }}</p>
+                  <!-- <p>{{ record.campus_event.name }}</p> -->
                 </div>
                 <div fxFlex="1 0 2%"></div>
               </div>
@@ -26,7 +26,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">时间</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ record.campus_event.time | date:'y.M.d H:mm' }}</p>
+                  <!-- <p>{{ record.campus_event.time | date:'y.M.d H:mm' }}</p> -->
                 </div>
                 <div fxFlex="1 0 2%"></div>
               </div>
@@ -35,7 +35,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">学时</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ record.campus_event.num_hours | number:"1.0-2" }}</p>
+                  <!-- <p>{{ record.campus_event.num_hours | number:"1.0-2" }}</p> -->
                 </div>
                 <div fxFlex="1 0 2%"></div>
               </div>
@@ -44,7 +44,7 @@
               fxLayoutGap="15px">
                 <span class="item-title" fxFlex="1 0 20%">人数</span>
                 <div class="item-content" fxFlex="1 0 78%">
-                  <p>{{ record.campus_event.num_participants }}</p>
+                  <!-- <p>{{ record.campus_event.num_participants }}</p> -->
                 </div>
                 <div fxFlex="1 0 2%"></div>
               </div>

--- a/src/app/training-record/components/record-detail/record-detail.component.spec.ts
+++ b/src/app/training-record/components/record-detail/record-detail.component.spec.ts
@@ -19,7 +19,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Location } from '@angular/common';
 
 import { RecordDetailComponent } from './record-detail.component';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { RecordService } from 'src/app/training-record/services/record.service';
 import { FeedbackDialogComponent } from 'src/app/training-record/components/feedback-dialog/feedback-dialog.component';
 import { OffCampusRecordDetailComponent } from 'src/app/shared/components/off-campus-record-detail/off-campus-record-detail.component';
@@ -70,20 +70,11 @@ describe('RecordDetailComponent', () => {
               create_time: '2019-01-01',
               update_time: '2019-01-02',
               campus_event: null,
-              off_campus_event: {id: 1,
-                                 create_time: '2019-03-02T09:07:57.159755+08:00',
-                                 update_time: '2019-03-02T09:07:57.159921+08:00',
-                                 name: 'sfdg',
-                                 time: '2019-03-02T00:00:00+08:00',
-                                 location: 'dfgfd',
-                                 num_hours: 0,
-                                 num_participants: 25
-                                 },
               contents: [],
               attachments: [],
               user: 1,
               status: 1,
-            } as RecordResponse}),
+            } as Record}),
           },
         },
         {

--- a/src/app/training-record/components/record-detail/record-detail.component.ts
+++ b/src/app/training-record/components/record-detail/record-detail.component.ts
@@ -4,7 +4,7 @@ import { MatDialog } from '@angular/material';
 import { Location } from '@angular/common';
 
 import { RecordService } from 'src/app/training-record/services/record.service';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { RecordStatus } from 'src/app/shared/enums/record-status.enum';
 import { FeedbackDialogComponent } from '../feedback-dialog/feedback-dialog.component';
 
@@ -16,7 +16,7 @@ import { FeedbackDialogComponent } from '../feedback-dialog/feedback-dialog.comp
 })
 export class RecordDetailComponent implements OnInit {
   /** The data to be displayed. */
-  record: RecordResponse;
+  record: Record;
   isCampusEventRecord: boolean;
   hasFeedbackSent: boolean;
   feedback: string;
@@ -29,8 +29,8 @@ export class RecordDetailComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    /** The record in this component will subscribe to RecordResponse data returned by route. */
-    this.route.data.subscribe((data: { record: RecordResponse }) => {
+    /** The record in this component will subscribe to Record data returned by route. */
+    this.route.data.subscribe((data: { record: Record }) => {
       this.record = data.record;
       this.isCampusEventRecord = Boolean(this.record.campus_event);
       this.hasFeedbackSent = this.record.status === RecordStatus.STATUS_WITH_FEEDBACK;

--- a/src/app/training-record/components/record-form/record-form.component.spec.ts
+++ b/src/app/training-record/components/record-form/record-form.component.spec.ts
@@ -23,10 +23,10 @@ import { Router } from '@angular/router';
 import { RecordFormComponent } from './record-form.component';
 import { RecordService } from '../../services/record.service';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { HttpErrorResponse } from '@angular/common/http';
 import { EventService } from 'src/app/training-event/services/event.service';
-import { OffCampusEventResponse } from 'src/app/shared/interfaces/event';
+import { OffCampusEvent } from 'src/app/shared/interfaces/event';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
 
 describe('RecordFormComponent', () => {
@@ -36,15 +36,15 @@ describe('RecordFormComponent', () => {
   // respond to new value. This is not a big deal in unit tests, but we
   // need to make sure that we are aware of the consequences of this
   // behavior, such as codes are marked run multiple times in coverage report.
-  let createOffCampusRecord$: Subject<RecordResponse>;
-  let getOffCampusEvents$: Subject<PaginatedResponse<OffCampusEventResponse>>;
+  let createOffCampusRecord$: Subject<Record>;
+  let getOffCampusEvents$: Subject<PaginatedResponse<OffCampusEvent>>;
   let getOffCampusEvents: jasmine.Spy;
   let navigate: jasmine.Spy;
   let snackBarOpen: jasmine.Spy;
   let component: RecordFormComponent;
   let fixture: ComponentFixture<RecordFormComponent>;
 
-  const dummyEvent: OffCampusEventResponse = {
+  const dummyEvent: OffCampusEvent = {
     id: 5,
     name: 'abc',
     time: 'time',
@@ -179,7 +179,7 @@ describe('RecordFormComponent', () => {
 
   it('should navigate when creation succeed.', () => {
     component.onSubmit();
-    createOffCampusRecord$.next({ id: 123 } as RecordResponse);
+    createOffCampusRecord$.next({ id: 123 } as Record);
 
     expect(navigate).toHaveBeenCalledWith(['../record-detail/', 123]);
   });
@@ -225,7 +225,7 @@ describe('RecordFormComponent', () => {
   }));
 
   it('should set fields with selected option', () => {
-    const offCampusEvent: OffCampusEventResponse = {
+    const offCampusEvent: OffCampusEvent = {
       id: 1,
       name: 'abc',
       time: '2019-01-01 12:34:45',

--- a/src/app/training-record/components/record-form/record-form.component.ts
+++ b/src/app/training-record/components/record-form/record-form.component.ts
@@ -4,15 +4,16 @@ import { Router } from '@angular/router';
 
 import { RecordService } from '../../services/record.service';
 import { AuthService, AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
-import { OffCampusEventRequest, OffCampusEventResponse } from 'src/app/shared/interfaces/event';
-import { RecordContent, RecordRequest } from 'src/app/shared/interfaces/record';
-import { ContentType } from 'src/app/shared/enums/content-type.enum';
+import { OffCampusEvent } from 'src/app/shared/interfaces/event';
+import { Record } from 'src/app/shared/interfaces/record';
 import { MatSnackBar, MatAutocompleteSelectedEvent, MatAutocomplete } from '@angular/material';
 import { HttpErrorResponse } from '@angular/common/http';
 import { EventService } from 'src/app/training-event/services/event.service';
 import { Observable } from 'rxjs';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
 import { switchMap, map, debounceTime } from 'rxjs/operators';
+import { ContentType } from 'src/app/shared/enums/content-type.enum';
+import { RecordContent } from 'src/app/shared/interfaces/record-content';
 
 interface FileChangeEvent extends Event {
   target: HTMLInputElement & EventTarget;
@@ -39,7 +40,7 @@ export class RecordFormComponent implements OnInit {
   });
 
   @ViewChild(MatAutocomplete) autoComplete: MatAutocomplete;
-  filteredOptions: Observable<OffCampusEventResponse[]>;
+  filteredOptions: Observable<OffCampusEvent[]>;
 
   /** The attachments to be uploaded. */
   attachments: File[] = [];
@@ -58,12 +59,12 @@ export class RecordFormComponent implements OnInit {
     this.filteredOptions = this.name.valueChanges.pipe(
       debounceTime(1000),
       switchMap(prefix => this._filter(prefix)),
-      map((value: PaginatedResponse<OffCampusEventResponse>) => value.results),
+      map((value: PaginatedResponse<OffCampusEvent>) => value.results),
     );
 
     // Update form when the auto-complete option is selected.
     this.autoComplete.optionSelected.subscribe((event: MatAutocompleteSelectedEvent) => {
-      const offCampusEvent = event.option.value as OffCampusEventResponse;
+      const offCampusEvent = event.option.value as OffCampusEvent;
       this.name.setValue(offCampusEvent.name);
       this.time.setValue(offCampusEvent.time);
       this.location.setValue(offCampusEvent.location);
@@ -156,20 +157,20 @@ export class RecordFormComponent implements OnInit {
     ].filter((val) => val.content !== '');
   }
 
-  private buildOffCampusEventRequest(): OffCampusEventRequest {
-    const value = this.recordForm.value;
-    return {
-      name: value.name,
-      time: value.time,
-      location: value.location,
-      num_hours: value.numHours,
-      num_participants: value.numParticipants,
-    };
-  }
+  // TODO: Fix below and remove this comment
+  // private buildOffCampusEvent(): OffCampusEvent {
+  //   const value = this.recordForm.value;
+  //   return {
+  //     name: value.name,
+  //     time: value.time,
+  //     location: value.location,
+  //     num_hours: value.numHours,
+  //     num_participants: value.numParticipants,
+  //   };
+  // }
 
   onSubmit() {
-    const req: RecordRequest = {
-      off_campus_event: this.buildOffCampusEventRequest(),
+    const req: Record = {
       user: this.authService.userID,
       contents: this.buildContents(),
       attachments: this.attachments,

--- a/src/app/training-record/components/record-list/record-list.component.ts
+++ b/src/app/training-record/components/record-list/record-list.component.ts
@@ -2,7 +2,7 @@ import { Component} from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { RecordService } from '../../services/record.service';
 import { GenericListComponent } from 'src/app/shared/generics/generic-list/generic-list';
 
@@ -12,7 +12,7 @@ import { GenericListComponent } from 'src/app/shared/generics/generic-list/gener
   templateUrl: './record-list.component.html',
   styleUrls: ['./record-list.component.css']
 })
-export class RecordListComponent extends GenericListComponent<RecordResponse> {
+export class RecordListComponent extends GenericListComponent<Record> {
   constructor(
     protected readonly route: ActivatedRoute,
     protected readonly router: Router,

--- a/src/app/training-record/services/record-attachment.service.spec.ts
+++ b/src/app/training-record/services/record-attachment.service.spec.ts
@@ -3,12 +3,12 @@ import { HttpTestingController, HttpClientTestingModule } from '@angular/common/
 
 import { RecordAttachmentService } from './record-attachment.service';
 import { environment } from 'src/environments/environment';
-import { RecordAttachmentRequest } from 'src/app/shared/interfaces/record';
+import { RecordAttachment } from 'src/app/shared/interfaces/record-attachment';
 
 
 describe('RecordAttachmentService', () => {
   let httpTestingController: HttpTestingController;
-  const dummyReq: RecordAttachmentRequest = {
+  const dummyReq: RecordAttachment = {
     record: 1,
     path: new File([''], 'file'),
   };

--- a/src/app/training-record/services/record-attachment.service.ts
+++ b/src/app/training-record/services/record-attachment.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { zip, of as observableOf } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
-import { RecordAttachmentResponse, RecordAttachmentRequest } from 'src/app/shared/interfaces/record';
+import { RecordAttachment } from 'src/app/shared/interfaces/record-attachment';
 
 /** Export services for RecordAttachment. */
 @Injectable({
@@ -16,16 +16,16 @@ export class RecordAttachmentService {
   ) { }
 
   /** Create single attachment. */
-  createRecordAttachment(req: RecordAttachmentRequest) {
+  createRecordAttachment(req: RecordAttachment) {
     const data = new FormData();
     data.set('record', req.record.toString());
-    data.set('path', req.path, req.path.name);
-    return this.http.post<RecordAttachmentResponse>(
+    data.set('path', req.path, (req.path as File).name);
+    return this.http.post<RecordAttachment>(
       `${environment.API_URL}/record-attachments/`, data);
   }
 
   /** Create multiple attachments. */
-  createRecordAttachments(reqs: RecordAttachmentRequest[]) {
+  createRecordAttachments(reqs: RecordAttachment[]) {
     if (reqs.length === 0) return observableOf([]);
     return zip(...reqs.map(req => this.createRecordAttachment(req)));
   }

--- a/src/app/training-record/services/record-content.service.spec.ts
+++ b/src/app/training-record/services/record-content.service.spec.ts
@@ -2,14 +2,14 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { RecordContentService } from './record-content.service';
-import { RecordContentRequest } from 'src/app/shared/interfaces/record';
+import { RecordContent } from 'src/app/shared/interfaces/record-content';
 
 import { environment } from 'src/environments/environment';
 import { ContentType } from 'src/app/shared/enums/content-type.enum';
 
 describe('RecordContentService', () => {
   let httpTestingController: HttpTestingController;
-  const dummyReq: RecordContentRequest = {
+  const dummyReq: RecordContent = {
     record: 1,
     content_type: ContentType.CONTENT_TYPE_CONTENT,
     content: 'abc',

--- a/src/app/training-record/services/record-content.service.ts
+++ b/src/app/training-record/services/record-content.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { zip, of as observableOf } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
-import { RecordContentRequest, RecordContentResponse } from 'src/app/shared/interfaces/record';
+import { RecordContent } from 'src/app/shared/interfaces/record-content';
 
 /** Provide services for RecordContent. */
 @Injectable({
@@ -16,13 +16,13 @@ export class RecordContentService {
   ) { }
 
   /** Create single content. */
-  createRecordContent(req: RecordContentRequest) {
-    return this.http.post<RecordContentResponse>(
+  createRecordContent(req: RecordContent) {
+    return this.http.post<RecordContent>(
       `${environment.API_URL}/record-contents/`, req);
   }
 
   /** Create multiple contents. */
-  createRecordContents(reqs: RecordContentRequest[]) {
+  createRecordContents(reqs: RecordContent[]) {
     if (reqs.length === 0) return observableOf([]);
     return zip(...reqs.map(req => this.createRecordContent(req)));
   }

--- a/src/app/training-record/services/record-detail-resolver.service.ts
+++ b/src/app/training-record/services/record-detail-resolver.service.ts
@@ -3,19 +3,19 @@ import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/r
 import { Observable } from 'rxjs';
 
 import { RecordService } from './record.service';
-import { RecordResponse } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 
 /** Pre-fetching record data. */
 @Injectable({
   providedIn: 'root'
 })
-export class RecordDetailResolverService implements Resolve< RecordResponse > {
+export class RecordDetailResolverService implements Resolve< Record > {
 
   constructor(
     private readonly recordService: RecordService,
   ) { }
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<RecordResponse> {
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Record> {
     const id = +route.paramMap.get('id');
     return this.recordService.getRecord(id);
   }

--- a/src/app/training-record/services/record.service.spec.ts
+++ b/src/app/training-record/services/record.service.spec.ts
@@ -5,7 +5,7 @@ import { Subject, throwError } from 'rxjs';
 import { RecordService } from './record.service';
 
 import { environment } from 'src/environments/environment';
-import { RecordRequest } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { ContentType } from 'src/app/shared/enums/content-type.enum';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 
@@ -43,14 +43,8 @@ describe('RecordService', () => {
 
   it('should create off-campus record', () => {
     const service: RecordService = TestBed.get(RecordService);
-    const createReq: RecordRequest = {
-      off_campus_event: {
-        name: 'name',
-        location: 'loc',
-        time: 'time',
-        num_hours: 5,
-        num_participants: 30,
-      },
+    const createReq: Record = {
+      off_campus_event: 3,
       user: 1,
       contents: [
         {

--- a/src/app/training-record/services/record.service.ts
+++ b/src/app/training-record/services/record.service.ts
@@ -3,10 +3,11 @@ import { HttpClient } from '@angular/common/http';
 import { timer, of as observableOf } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
-import { RecordRequest, RecordResponse, } from 'src/app/shared/interfaces/record';
+import { Record } from 'src/app/shared/interfaces/record';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
 import { switchMap, catchError } from 'rxjs/operators';
+import { RecordContent } from 'src/app/shared/interfaces/record-content';
 
 /** Provide services for Record. */
 @Injectable({
@@ -28,14 +29,14 @@ export class RecordService extends GenericListService {
   }
 
   /** Create TrainingRecord along with its contents and attachments. */
-  createOffCampusRecord(req: RecordRequest) {
+  createOffCampusRecord(req: Record) {
     const data = new FormData();
     data.set('off_campus_event_data', JSON.stringify(req.off_campus_event));
     data.set('user', req.user.toString());
-    req.attachments.map(x => data.append('attachments_data', x));
-    req.contents.map(x => data.append('contents_data', JSON.stringify(x)));
+    (req.attachments as File[]).map(x => data.append('attachments_data', x));
+    (req.contents as RecordContent[]).map(x => data.append('contents_data', JSON.stringify(x)));
 
-    return this.http.post<RecordResponse>(
+    return this.http.post<Record>(
       `${environment.API_URL}/records/`, data);
   }
 
@@ -44,16 +45,16 @@ export class RecordService extends GenericListService {
   }
 
   getRecord(id: number) {
-    return this.http.get<RecordResponse>(
+    return this.http.get<Record>(
       `${environment.API_URL}/records/${id}/`);
   }
 
   getRecords(req: ListRequest) {
-    return this.list<RecordResponse>('records', req);
+    return this.list<Record>('records', req);
   }
 
   getReviewedRecords(req: ListRequest) {
-    return this.list<RecordResponse>('records/reviewed', req);
+    return this.list<Record>('records/reviewed', req);
   }
 
   getNumberOfRecordsWithoutFeedback() {


### PR DESCRIPTION
* Remove all `*Request` and `*Response` objects.
* Interfaces for backend objects are now strictly typed and marked as optional, nested representations have been cancelled.

FYI:
1. Codes that will break the unit tests after the change have been commented, please visit related pages and fix them accordingly.
2. If you find fields of  interfaces need to be updated, please update it as a union type, and later use type assertion to get correct type . e.g:
```typescript
export interface RecordAttachment {
  path?: File | string;
}
```
3. PLEASE remove all logic for retrieving nested objects, you can retrieve objects separately and assemble them in FE, for example:
```typescript
export interface A {
  nestedObjectB: number | B;
}

export interface B {
  ...
}
```
You get `nestedObjectB` as a numeric value when you first retrieving an object of `A`. After that, you can send another request for retrieving `nestedObjectB`, and then replace the `nestedObjectB` field with received `B` object.