### PR TITLE
Use HttpInterceptor to add host for relative urls. close #191

### DIFF
--- a/src/app/admin/modules/data-management/components/table-export/table-export.component.ts
+++ b/src/app/admin/modules/data-management/components/table-export/table-export.component.ts
@@ -1,6 +1,5 @@
 import { OnInit, Component } from '@angular/core';
 import { TableExportService } from 'src/app/shared/services/data/table-export.service';
-import { environment } from 'src/environments/environment';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { WindowService } from 'src/app/shared/services/window.service';
@@ -24,7 +23,7 @@ export class TableExportComponent implements OnInit {
     }
 
     doTableExport() {
-        const url = `${environment.API_URL}/data-management/table-export`;
+        const url = `/data-management/table-export`;
         this.tableExportService.exportTable(url).subscribe(
             data => {
                 this.windowService.open(data['url']);

--- a/src/app/admin/modules/permission-management/services/group.service.spec.ts
+++ b/src/app/admin/modules/permission-management/services/group.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { environment } from 'src/environments/environment';
 import { Department } from 'src/app/shared/interfaces/department';
 import { GroupService } from './group.service';
 
@@ -29,7 +28,7 @@ describe('GroupService', () => {
     const id = 5;
     service.getGroupById(5).subscribe();
 
-    const url = `${environment.API_URL}/groups/${id}/`;
+    const url = `/groups/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -41,7 +40,7 @@ describe('GroupService', () => {
     service.getGroupByDepartmentName(department.name).subscribe();
 
     const params = `name__startswith=${department.name}`;
-    const url = `${environment.API_URL}/groups/?${params}`;
+    const url = `/groups/?${params}`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');

--- a/src/app/admin/modules/permission-management/services/group.service.ts
+++ b/src/app/admin/modules/permission-management/services/group.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { Group } from 'src/app/shared/interfaces/group';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
@@ -14,11 +13,11 @@ export class GroupService {
   ) { }
 
   getGroupById(id: number) {
-    return this.http.get<Group>(`${environment.API_URL}/groups/${id}/`);
+    return this.http.get<Group>(`/groups/${id}/`);
   }
 
   getGroupByDepartmentName(name: string) {
     return this.http.get<PaginatedResponse<Group>>(
-      `${environment.API_URL}/groups/?name__startswith=${name}`);
+      `/groups/?name__startswith=${name}`);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,8 @@ import { SharedModule } from './shared/shared.module';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CookieService } from 'ngx-cookie-service';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { APIHostInterceptor } from './core/api-host-interceptor/apihost-interceptor.interceptor';
 
 registerLocaleData(localeZhHans, 'zh-Hans');
 
@@ -67,6 +69,11 @@ export function tokenGetter() {
     {
       provide: DOCUMENT,
       useValue: document,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: APIHostInterceptor,
+      multi: true,
     },
     CookieService,
   ],

--- a/src/app/core/api-host-interceptor/apihost-interceptor.interceptor.spec.ts
+++ b/src/app/core/api-host-interceptor/apihost-interceptor.interceptor.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { APIHostInterceptor } from './apihost-interceptor.interceptor';
+
+describe('APIHostInterceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: APIHostInterceptor = TestBed.get(APIHostInterceptor);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/api-host-interceptor/apihost-interceptor.interceptor.ts
+++ b/src/app/core/api-host-interceptor/apihost-interceptor.interceptor.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpHandler, HttpEvent, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+/** Add host for relative URLs, skip when URL is an absolute path. */
+@Injectable({
+  providedIn: 'root'
+})
+export class APIHostInterceptor implements HttpInterceptor {
+
+  constructor() { }
+
+  /* tslint:disable-next-line:no-any */
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const url = request.url;
+    if (url.startsWith('http')) {
+      return next.handle(request);
+    }
+    request = request.clone({
+      url: `${environment.API_URL}${url}`,
+    });
+    return next.handle(request);
+  }
+}

--- a/src/app/shared/generics/generic-list-service/generic-list-service.spec.ts
+++ b/src/app/shared/generics/generic-list-service/generic-list-service.spec.ts
@@ -48,7 +48,7 @@ describe('GenericListService', () => {
         const url = 'abc';
         service.getObjects(`/${url}/`, {}).subscribe();
 
-        const expectedUrl = `${environment.API_URL}/${url}/?limit=${environment.PAGINATION_SIZE}&offset=0`;
+        const expectedUrl = `/${url}/?limit=${environment.PAGINATION_SIZE}&offset=0`;
 
         const req = httpTestingController.expectOne(expectedUrl);
         expect(req.request.method).toBe('GET');
@@ -60,7 +60,7 @@ describe('GenericListService', () => {
         const extraParams = new Map<string, {}>([['name', 'def']]);
         service.getObjects(`/${url}/`, { extraParams }).subscribe();
 
-        const expectedUrl = `${environment.API_URL}/${url}/?limit=${environment.PAGINATION_SIZE}&name=def&offset=0`;
+        const expectedUrl = `/${url}/?limit=${environment.PAGINATION_SIZE}&name=def&offset=0`;
 
         const req = httpTestingController.expectOne(expectedUrl);
         expect(req.request.method).toBe('GET');

--- a/src/app/shared/generics/generic-list-service/generic-list-service.ts
+++ b/src/app/shared/generics/generic-list-service/generic-list-service.ts
@@ -23,7 +23,7 @@ export class GenericListService {
             key => key + '=' + encodeURIComponent(params.get(key).toString())).join('&');
 
         // Construct final URL
-        const url = `${environment.API_URL}/${resourceURL}/?${queryParams}`;
+        const url = `/${resourceURL}/?${queryParams}`;
         return this.http.get<PaginatedResponse<T>>(url);
     }
 }

--- a/src/app/shared/services/data/table-export.service.spec.ts
+++ b/src/app/shared/services/data/table-export.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { TableExportService } from './table-export.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { environment } from 'src/environments/environment';
 import { Subject } from 'rxjs';
 import { AUTH_SERVICE } from '../../interfaces/auth-service';
 
@@ -37,7 +36,7 @@ describe('TableExportService', () => {
 
   it('should export table', () => {
     const service: TableExportService = TestBed.get(TableExportService);
-    const url = `${environment.API_URL}/data-management/table-export`;
+    const url = `/data-management/table-export`;
     service.exportTable(url).subscribe();
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toBeTruthy('GET');

--- a/src/app/shared/services/department.service.spec.ts
+++ b/src/app/shared/services/department.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 
 import { DepartmentService } from './department.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { environment } from 'src/environments/environment';
 
 describe('DepartmentService', () => {
   let httpTestingController: HttpTestingController;
@@ -32,7 +31,7 @@ describe('DepartmentService', () => {
     service.getDepartments({ limit, offset }).subscribe();
 
     const params = `limit=${limit}&offset=${offset}`;
-    const url = `${environment.API_URL}/departments/?${params}`;
+    const url = `/departments/?${params}`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -44,7 +43,7 @@ describe('DepartmentService', () => {
     const id = 5;
     service.getDepartment(id).subscribe();
 
-    const url = `${environment.API_URL}/departments/${id}/`;
+    const url = `/departments/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');

--- a/src/app/shared/services/department.service.ts
+++ b/src/app/shared/services/department.service.ts
@@ -3,7 +3,6 @@ import { GenericListService } from '../generics/generic-list-service/generic-lis
 import { HttpClient } from '@angular/common/http';
 import { ListRequest } from '../interfaces/list-request';
 import { Department } from '../interfaces/department';
-import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -21,6 +20,6 @@ export class DepartmentService extends GenericListService {
   }
 
   getDepartment(id: Department|number) {
-    return this.http.get<Department>(`${environment.API_URL}/departments/${id}/`);
+    return this.http.get<Department>(`/departments/${id}/`);
   }
 }

--- a/src/app/shared/services/events/event.service.spec.ts
+++ b/src/app/shared/services/events/event.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { Subject } from 'rxjs';
 
 import { EventService } from './event.service';
-import { environment } from 'src/environments/environment';
 import {
   OffCampusEvent,
   CampusEvent,
@@ -42,7 +41,7 @@ describe('EventService', () => {
 
     service.getCampusEvents({}).subscribe();
 
-    const url = `${environment.API_URL}/campus-events/?limit=10&offset=0`;
+    const url = `/campus-events/?limit=10&offset=0`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -54,7 +53,7 @@ describe('EventService', () => {
 
     service.getOffCampusEvents({}).subscribe();
 
-    const url = `${environment.API_URL}/off-campus-events/?limit=10&offset=0`;
+    const url = `/off-campus-events/?limit=10&offset=0`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -67,7 +66,7 @@ describe('EventService', () => {
 
     service.getEvent(id).subscribe();
 
-    const url = `${environment.API_URL}/campus-events/${id}/`;
+    const url = `/campus-events/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -80,7 +79,7 @@ describe('EventService', () => {
 
     service.getOffCampusEvent(id).subscribe();
 
-    const url = `${environment.API_URL}/off-campus-events/${id}/`;
+    const url = `/off-campus-events/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -103,7 +102,7 @@ describe('EventService', () => {
       num_participants: 50,
     } as OffCampusEvent).subscribe();
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/off-campus-events/`);
+      `/off-campus-events/`);
     expect(req.request.method).toEqual('POST');
     req.flush({
       name: 'name',
@@ -120,7 +119,7 @@ describe('EventService', () => {
 
     service.deleteOffCampusEvent(id).subscribe();
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/off-campus-events/${id}/`);
+      `/off-campus-events/${id}/`);
     expect(req.request.method).toEqual('DELETE');
     req.flush({});
   });
@@ -142,7 +141,7 @@ describe('EventService', () => {
     service.createCampusEvent(createReq).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/campus-events/`);
+      `/campus-events/`);
     expect(req.request.method).toBe('POST');
     req.flush({});
   });

--- a/src/app/shared/services/events/event.service.ts
+++ b/src/app/shared/services/events/event.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
-import { environment } from 'src/environments/environment';
 import {
   OffCampusEvent,
   CampusEvent,
@@ -23,7 +22,7 @@ export class EventService extends GenericListService {
 
   getEvent(id: number) {
     return this.http.get<CampusEvent>(
-      `${environment.API_URL}/campus-events/${id}/`);
+      `/campus-events/${id}/`);
   }
 
   /** Retrieve campus events. */
@@ -35,18 +34,18 @@ export class EventService extends GenericListService {
   /** Create an off-campus event. */
   createOffCampusEvent(req: OffCampusEvent) {
     return this.http.post<OffCampusEvent>(
-      `${environment.API_URL}/off-campus-events/`, req);
+      `/off-campus-events/`, req);
   }
 
   /** Delete the off-campus event based on eventID. */
   deleteOffCampusEvent(eventID: number) {
     return this.http.delete(
-      `${environment.API_URL}/off-campus-events/${eventID}/`);
+      `/off-campus-events/${eventID}/`);
   }
 
   getOffCampusEvent(eventID: number) {
     return this.http.get<OffCampusEvent>(
-      `${environment.API_URL}/off-campus-events/${eventID}/`);
+      `/off-campus-events/${eventID}/`);
   }
 
   /** Retrieve off-campus events, it's frequently used in AutoComplete. */
@@ -57,7 +56,7 @@ export class EventService extends GenericListService {
   /**  Admin create campus event */
   createCampusEvent(req: CampusEvent) {
     return this.http.post<CampusEvent>(
-      `${environment.API_URL}/campus-events/`, req);
+      `/campus-events/`, req);
   }
 
 }

--- a/src/app/shared/services/http-auth.service.spec.ts
+++ b/src/app/shared/services/http-auth.service.spec.ts
@@ -106,7 +106,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/login/`);
+      `/login/`);
 
     expect(req.request.method).toEqual('POST');
     req.flush(dummyResponse);
@@ -122,7 +122,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/login/`);
+      `/login/`);
 
     expect(req.request.method).toEqual('POST');
     req.flush({ msg: 'invalid' }, { status: 400, statusText: 'failed' });
@@ -142,7 +142,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/jwt-verify/`);
+      `/jwt-verify/`);
     expect(req.request.method).toEqual('POST');
 
     req.flush(dummyResponse);
@@ -164,7 +164,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/jwt-verify/`);
+      `/jwt-verify/`);
     expect(req.request.method).toEqual('POST');
 
     const dummyResponseWithoutDepartmentName: JWTResponse = {
@@ -213,7 +213,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/jwt-verify/`);
+      `/jwt-verify/`);
 
     expect(req.request.method).toEqual('POST');
     req.flush({ msg: 'invalid' }, { status: 400, statusText: 'failed' });
@@ -229,7 +229,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/jwt-refresh/`);
+      `/jwt-refresh/`);
 
     expect(req.request.method).toEqual('POST');
     req.flush(dummyResponse);
@@ -255,7 +255,7 @@ describe('HTTPAuthService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/jwt-refresh/`);
+      `/jwt-refresh/`);
 
     expect(req.request.method).toEqual('POST');
     req.flush({ msg: 'invalid' }, { status: 400, statusText: 'failed' });

--- a/src/app/shared/services/http-auth.service.ts
+++ b/src/app/shared/services/http-auth.service.ts
@@ -84,7 +84,7 @@ export class HTTPAuthService implements AuthService {
   retrieveJWT(ticket: string, service: string): Observable<boolean> {
     const payload = { ticket, service };
     return this.http.post<JWTResponse>(
-      `${environment.API_URL}/login/`, payload).pipe(
+      `/login/`, payload).pipe(
       map(response => {
         this.authenticate(response);
         return true;
@@ -114,11 +114,11 @@ export class HTTPAuthService implements AuthService {
 
   /* Request server to verify the JWT. */
   verifyJWT(): Observable<boolean> {
-    return this.sendJWT(`${environment.API_URL}/jwt-verify/`);
+    return this.sendJWT(`/jwt-verify/`);
   }
 
   /* Request server to refresh the JWT. */
   refreshJWT(): Observable<boolean> {
-    return this.sendJWT(`${environment.API_URL}/jwt-refresh/`);
+    return this.sendJWT(`/jwt-refresh/`);
   }
 }

--- a/src/app/shared/services/notification.service.spec.ts
+++ b/src/app/shared/services/notification.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { of as observableOf, throwError, Subject } from 'rxjs';
 
 import { NotificationService } from './notification.service';
-import { environment } from 'src/environments/environment';
 import { Notification } from 'src/app/shared/interfaces/notification';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
@@ -63,7 +62,7 @@ describe('NotificationService', () => {
       res => { expect(res.results.length).toEqual(2); });
 
     const params = `limit=${limit}&offset=${offset}`;
-    const url = `${environment.API_URL}/notifications/read/?${params}`;
+    const url = `/notifications/read/?${params}`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -81,7 +80,7 @@ describe('NotificationService', () => {
       });
 
     const params = `limit=${limit}&offset=${offset}`;
-    const url = `${environment.API_URL}/notifications/unread/?${params}`;
+    const url = `/notifications/unread/?${params}`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -126,7 +125,7 @@ describe('NotificationService', () => {
       });
 
     const params = `limit=10&offset=0`;
-    const url = `${environment.API_URL}/notifications/?${params}`;
+    const url = `/notifications/?${params}`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -139,7 +138,7 @@ describe('NotificationService', () => {
 
     service.getNotification(id).subscribe();
 
-    const url = `${environment.API_URL}/notifications/${id}/`;
+    const url = `/notifications/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -151,7 +150,7 @@ describe('NotificationService', () => {
 
     service.markAllNotificationsAsRead().subscribe();
 
-    const url = `${environment.API_URL}/notifications/mark-all-as-read/`;
+    const url = `/notifications/mark-all-as-read/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('POST');

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -43,7 +43,7 @@ export class NotificationService extends GenericListService {
 
   getNotification(id: number) {
     return this.http.get<Notification>(
-      `${environment.API_URL}/notifications/${id}/`);
+      `/notifications/${id}/`);
   }
 
   /** API for retrieving notifications. */
@@ -63,6 +63,6 @@ export class NotificationService extends GenericListService {
 
   /** Mark all notifications for user as read. */
   markAllNotificationsAsRead() {
-    return this.http.post(`${environment.API_URL}/notifications/mark-all-as-read/`, {});
+    return this.http.post(`/notifications/mark-all-as-read/`, {});
   }
 }

--- a/src/app/shared/services/permission.service.spec.ts
+++ b/src/app/shared/services/permission.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 
 import { PermissionService } from './permission.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { environment } from 'src/environments/environment';
 import { UserPermission, GroupPermission } from 'src/app/shared/interfaces/permission';
 import { Subject } from 'rxjs';
 import { PaginatedResponse } from 'src/app/shared/interfaces/paginated-response';
@@ -44,7 +43,7 @@ describe('PermissionService', () => {
     service.getPermissions().subscribe(() => { });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/permissions/?limit=-1`);
+      `/permissions/?limit=-1`);
 
     expect(req.request.method).toEqual('GET');
     req.flush({});
@@ -56,7 +55,7 @@ describe('PermissionService', () => {
     service.getPermissions().subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/permissions/?limit=-1`);
+      `/permissions/?limit=-1`);
 
     expect(req.request.method).toEqual('GET');
     req.flush({});
@@ -83,7 +82,7 @@ describe('PermissionService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/user-permissions/?user=${userId}&limit=-1`);
+      `/user-permissions/?user=${userId}&limit=-1`);
 
     expect(req.request.method).toEqual('GET');
     req.flush(dummyResponse);
@@ -98,7 +97,7 @@ describe('PermissionService', () => {
     }).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/user-permissions/`);
+      `/user-permissions/`);
 
     expect(req.request.method).toEqual('POST');
     req.flush({});
@@ -119,7 +118,7 @@ describe('PermissionService', () => {
     ]).subscribe();
 
     const req = httpTestingController.match(
-      `${environment.API_URL}/user-permissions/`);
+      `/user-permissions/`);
 
     expect(req.length).toBe(2);
     expect(req[0].request.method).toEqual('POST');
@@ -134,7 +133,7 @@ describe('PermissionService', () => {
     service.deleteUserPermission(permissionId).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/user-permissions/${permissionId}/`);
+      `/user-permissions/${permissionId}/`);
 
     expect(req.request.method).toEqual('DELETE');
     req.flush({});
@@ -148,7 +147,7 @@ describe('PermissionService', () => {
 
     permissionIds.map(x => {
       const req = httpTestingController.expectOne(
-        `${environment.API_URL}/user-permissions/${x}/`);
+        `/user-permissions/${x}/`);
 
       expect(req.request.method).toEqual('DELETE');
       req.flush({});
@@ -189,7 +188,7 @@ describe('PermissionService', () => {
     });
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/group-permissions/?group=${groupId}&limit=-1`);
+      `/group-permissions/?group=${groupId}&limit=-1`);
 
     expect(req.request.method).toEqual('GET');
     req.flush(dummyResponse);

--- a/src/app/shared/services/permission.service.ts
+++ b/src/app/shared/services/permission.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { Observable, zip, of as observableOf } from 'rxjs';
 import { Permission, UserPermission, GroupPermission } from '../interfaces/permission';
 import { HttpClient } from '@angular/common/http';
-import { environment } from 'src/environments/environment';
 import { tap } from 'rxjs/operators';
 
 /** This service manages Permission objects and UserPermission objects. */
@@ -22,7 +21,7 @@ export class PermissionService {
     if (this.permissions.length !== 0) {
       return observableOf(this.permissions);
     }
-    return this.http.get<Permission[]>(`${environment.API_URL}/permissions/?limit=-1`).pipe(
+    return this.http.get<Permission[]>(`/permissions/?limit=-1`).pipe(
       tap((permissions: Permission[]) => {
         this.permissions = permissions;
       })
@@ -32,11 +31,11 @@ export class PermissionService {
   /** Retrieve user's permissions. */
   getUserPermissions(userId: number): Observable<UserPermission[]> {
     return this.http.get<UserPermission[]>(
-      `${environment.API_URL}/user-permissions/?user=${userId}&limit=-1`);
+      `/user-permissions/?user=${userId}&limit=-1`);
   }
 
   createUserPermission(req: UserPermission) {
-    return this.http.post(`${environment.API_URL}/user-permissions/`, req);
+    return this.http.post(`/user-permissions/`, req);
   }
 
   createUserPermissions(reqs: UserPermission[]) {
@@ -46,7 +45,7 @@ export class PermissionService {
   }
 
   deleteUserPermission(permissionId: number) {
-    return this.http.delete(`${environment.API_URL}/user-permissions/${permissionId}/`);
+    return this.http.delete(`/user-permissions/${permissionId}/`);
   }
 
   deleteUserPermissions(permissionIds: number[]) {
@@ -57,6 +56,6 @@ export class PermissionService {
 
   getGroupPermissions(groupId: number): Observable<GroupPermission[]> {
     return this.http.get<GroupPermission[]>(
-      `${environment.API_URL}/group-permissions/?group=${groupId}&limit=-1`);
+      `/group-permissions/?group=${groupId}&limit=-1`);
   }
 }

--- a/src/app/shared/services/programs/program.service.spec.ts
+++ b/src/app/shared/services/programs/program.service.spec.ts
@@ -6,7 +6,6 @@ import { Department } from 'src/app/shared/interfaces/department';
 import { ProgramCategory } from 'src/app/shared/interfaces/program-category';
 import { ProgramService } from './program.service';
 import { DepartmentService } from 'src/app/shared/services/department.service';
-import { environment } from 'src/environments/environment';
 import { Program } from 'src/app/shared/interfaces/program';
 import { AUTH_SERVICE } from 'src/app/shared/interfaces/auth-service';
 
@@ -60,7 +59,7 @@ describe('ProgramService', () => {
 
     service.getPrograms({}).subscribe();
 
-    const url = `${environment.API_URL}/programs/?limit=10&offset=0`;
+    const url = `/programs/?limit=10&offset=0`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -73,7 +72,7 @@ describe('ProgramService', () => {
 
     service.getProgram(id).subscribe();
 
-    const url = `${environment.API_URL}/programs/${id}/`;
+    const url = `/programs/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -107,7 +106,7 @@ describe('ProgramService', () => {
     service.getProgramCategories().subscribe((data: ProgramCategory[]) => {
       expect(data.length).toEqual(2);
     });
-    const url = `${environment.API_URL}/program-categories/`;
+    const url = `/program-categories/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -123,7 +122,7 @@ describe('ProgramService', () => {
 
     service.getPrograms({}).subscribe();
 
-    const url = `${environment.API_URL}/programs/?limit=10&offset=0`;
+    const url = `/programs/?limit=10&offset=0`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -142,7 +141,7 @@ describe('ProgramService', () => {
     service.createProgram(createReq).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/programs/`);
+      `/programs/`);
     expect(req.request.method).toBe('POST');
     req.flush({});
   });

--- a/src/app/shared/services/programs/program.service.ts
+++ b/src/app/shared/services/programs/program.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, switchMap, tap } from 'rxjs/operators';
 
-import { environment } from 'src/environments/environment';
 import { Program } from 'src/app/shared/interfaces/program';
 import { ProgramCategory } from 'src/app/shared/interfaces/program-category';
 
@@ -33,7 +32,7 @@ export class ProgramService extends GenericListService {
   /** get the information of one program from the background. */
   getProgram(id: number) {
     return this.http.get<Program>(
-      `${environment.API_URL}/programs/${id}/`);
+      `/programs/${id}/`);
   }
 
   getProgramWithDetail(id: number) {
@@ -58,7 +57,7 @@ export class ProgramService extends GenericListService {
     if (this.cachedProgramCategories.length !== 0) {
       return observableOf(this.cachedProgramCategories);
     }
-    return this.http.get<ProgramCategory[]>(`${environment.API_URL}/program-categories/`).pipe(
+    return this.http.get<ProgramCategory[]>(`/program-categories/`).pipe(
       tap(data => this.cachedProgramCategories = data),
     );
   }
@@ -66,6 +65,6 @@ export class ProgramService extends GenericListService {
   /** create admin-program-form. */
   createProgram(req: Program) {
     return this.http.post<Program>(
-      `${environment.API_URL}/programs/`, req);
+      `/programs/`, req);
   }
 }

--- a/src/app/shared/services/records/record-attachment.service.spec.ts
+++ b/src/app/shared/services/records/record-attachment.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { RecordAttachmentService } from './record-attachment.service';
-import { environment } from 'src/environments/environment';
 
 
 describe('RecordAttachmentService', () => {
@@ -26,7 +25,7 @@ describe('RecordAttachmentService', () => {
 
     service.getRecordAttachment(id).subscribe();
 
-    const url = `${environment.API_URL}/record-attachments/${id}/`;
+    const url = `/record-attachments/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -39,7 +38,7 @@ describe('RecordAttachmentService', () => {
     service.getRecordAttachments([1, 2]).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/record-attachments/?id__in=1%2C2`);
+      `/record-attachments/?id__in=1%2C2`);
 
     expect(req.request.method).toEqual('GET');
 
@@ -60,7 +59,7 @@ describe('RecordAttachmentService', () => {
 
     service.deleteRecordAttachment(id).subscribe();
 
-    const url = `${environment.API_URL}/record-attachments/${id}/`;
+    const url = `/record-attachments/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('DELETE');

--- a/src/app/shared/services/records/record-attachment.service.ts
+++ b/src/app/shared/services/records/record-attachment.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { of as observableOf } from 'rxjs';
 
-import { environment } from 'src/environments/environment';
 import { RecordAttachment } from 'src/app/shared/interfaces/record-attachment';
 import { PaginatedResponse } from '../../interfaces/paginated-response';
 
@@ -19,7 +18,7 @@ export class RecordAttachmentService {
   /** Get single attachment. */
   getRecordAttachment(id: number) {
     return this.http.get<RecordAttachment>(
-      `${environment.API_URL}/record-attachments/${id}/`
+      `/record-attachments/${id}/`
     );
   }
 
@@ -30,10 +29,10 @@ export class RecordAttachmentService {
     const queryParams = 'id__in=' + encodeURIComponent(ids.toString());
 
     return this.http.get<PaginatedResponse<RecordAttachment>>(
-      `${environment.API_URL}/record-attachments/?${queryParams}`);
+      `/record-attachments/?${queryParams}`);
   }
 
   deleteRecordAttachment(id: number) {
-    return this.http.delete(`${environment.API_URL}/record-attachments/${id}/`);
+    return this.http.delete(`/record-attachments/${id}/`);
   }
 }

--- a/src/app/shared/services/records/record-content.service.spec.ts
+++ b/src/app/shared/services/records/record-content.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpTestingController, HttpClientTestingModule } from '@angular/common/
 
 import { RecordContentService } from './record-content.service';
 
-import { environment } from 'src/environments/environment';
 
 describe('RecordContentService', () => {
   let httpTestingController: HttpTestingController;
@@ -27,7 +26,7 @@ describe('RecordContentService', () => {
 
     service.getRecordContent(id).subscribe();
 
-    const url = `${environment.API_URL}/record-contents/${id}/`;
+    const url = `/record-contents/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -40,7 +39,7 @@ describe('RecordContentService', () => {
     service.getRecordContents([1, 2]).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/record-contents/?id__in=1%2C2`);
+      `/record-contents/?id__in=1%2C2`);
 
     expect(req.request.method).toEqual('GET');
 

--- a/src/app/shared/services/records/record-content.service.ts
+++ b/src/app/shared/services/records/record-content.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { of as observableOf } from 'rxjs';
 
-import { environment } from 'src/environments/environment';
 import { RecordContent } from 'src/app/shared/interfaces/record-content';
 import { PaginatedResponse } from '../../interfaces/paginated-response';
 
@@ -19,7 +18,7 @@ export class RecordContentService {
   /** Get single content. */
   getRecordContent(id: number) {
     return this.http.get<RecordContent>(
-      `${environment.API_URL}/record-contents/${id}/`
+      `/record-contents/${id}/`
     );
   }
 
@@ -30,6 +29,6 @@ export class RecordContentService {
     const queryParams = 'id__in=' + encodeURIComponent(ids.toString());
 
     return this.http.get<PaginatedResponse<RecordContent>>(
-      `${environment.API_URL}/record-contents/?${queryParams}`);
+      `/record-contents/?${queryParams}`);
   }
 }

--- a/src/app/shared/services/records/record.service.spec.ts
+++ b/src/app/shared/services/records/record.service.spec.ts
@@ -101,7 +101,7 @@ describe('RecordService', () => {
     service.createOffCampusRecord(createReq).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/records/`);
+      `/records/`);
     expect(req.request.method).toBe('POST');
     const form = req.request.body as FormData;
     expect(form.has('off_campus_event')).toBeTruthy();
@@ -118,7 +118,7 @@ describe('RecordService', () => {
     service.deleteRecord(id).subscribe();
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/records/${id}/`);
+      `/records/${id}/`);
     expect(req.request.method).toBe('DELETE');
     req.flush({});
   });
@@ -135,7 +135,7 @@ describe('RecordService', () => {
 
     service.updateOffCampusRecord(updateReq).subscribe();
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/records/1/`);
+      `/records/1/`);
     expect(req.request.method).toBe('PATCH');
     req.flush({});
   });
@@ -145,7 +145,7 @@ describe('RecordService', () => {
 
     service.getRecords({}).subscribe();
 
-    const url = `${environment.API_URL}/records/?limit=10&offset=0`;
+    const url = `/records/?limit=10&offset=0`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -213,7 +213,7 @@ describe('RecordService', () => {
 
     service.getReviewedRecords({}).subscribe();
 
-    const url = `${environment.API_URL}/records/reviewed/?limit=10&offset=0`;
+    const url = `/records/reviewed/?limit=10&offset=0`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -236,7 +236,7 @@ describe('RecordService', () => {
 
     service.getRecord(id).subscribe();
 
-    const url = `${environment.API_URL}/records/${id}/`;
+    const url = `/records/${id}/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('GET');
@@ -319,7 +319,7 @@ describe('RecordService', () => {
 
     service.batchSubmitRecord(new File([], 'a.xlsx')).subscribe();
 
-    const url = `${environment.API_URL}/records/batch-submit/`;
+    const url = `/records/batch-submit/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('POST');
@@ -331,7 +331,7 @@ describe('RecordService', () => {
 
     service.createFeedback(1, '').subscribe();
 
-    const url = `${environment.API_URL}/campus-event-feedbacks/`;
+    const url = `/campus-event-feedbacks/`;
 
     const req = httpTestingController.expectOne(url);
     expect(req.request.method).toEqual('POST');

--- a/src/app/shared/services/records/record.service.ts
+++ b/src/app/shared/services/records/record.service.ts
@@ -49,22 +49,22 @@ export class RecordService extends GenericListService {
   createOffCampusRecord(req: Record) {
     const data = this.buildRecordFormData(req);
     return this.http.post<Record>(
-      `${environment.API_URL}/records/`, data);
+      `/records/`, data);
   }
 
   updateOffCampusRecord(req: Record) {
     const data = this.buildRecordFormData(req);
     return this.http.patch<Record>(
-      `${environment.API_URL}/records/${req.id}/`, data);
+      `/records/${req.id}/`, data);
   }
 
   deleteRecord(recordID: number) {
-    return this.http.delete(`${environment.API_URL}/records/${recordID}/`);
+    return this.http.delete(`/records/${recordID}/`);
   }
 
   getRecord(id: number) {
     return this.http.get<Record>(
-      `${environment.API_URL}/records/${id}/`);
+      `/records/${id}/`);
   }
 
   getRecordWithDetail(id: number) {
@@ -139,19 +139,19 @@ export class RecordService extends GenericListService {
   }
 
   getNumberOfRecordsWithoutFeedback() {
-    return this.http.get<{'count': number}>(`${environment.API_URL}/records/no-feedback-records-count/`);
+    return this.http.get<{'count': number}>(`/records/no-feedback-records-count/`);
   }
 
   batchSubmitRecord(file: File) {
     const data = new FormData();
     data.set('file', file);
-    return this.http.post<{'count': number}>(`${environment.API_URL}/records/batch-submit/`, data);
+    return this.http.post<{'count': number}>(`/records/batch-submit/`, data);
   }
 
   createFeedback(recordID: number, feedbackData: string) {
     const data = new FormData();
     data.set('record', recordID.toString());
     data.set('content', feedbackData);
-    return this.http.post(`${environment.API_URL}/campus-event-feedbacks/`, data);
+    return this.http.post(`/campus-event-feedbacks/`, data);
   }
 }

--- a/src/app/shared/services/records/review-note.service.spec.ts
+++ b/src/app/shared/services/records/review-note.service.spec.ts
@@ -33,7 +33,7 @@ describe('ReviewNoteService', () => {
 
     service.getReviewNotes({ extraParams }).subscribe();
 
-    const expectedUrl = `${environment.API_URL}/${url}/?limit=${environment.PAGINATION_SIZE}&offset=0&record=3&user=87`;
+    const expectedUrl = `/${url}/?limit=${environment.PAGINATION_SIZE}&offset=0&record=3&user=87`;
 
     const req = httpTestingController.expectOne(expectedUrl);
     expect(req.request.method).toEqual('GET');
@@ -56,7 +56,7 @@ describe('ReviewNoteService', () => {
 
     service.createReviewNote(dres, notecontent).subscribe();
 
-    const req = httpTestingController.expectOne(`${environment.API_URL}/review-notes/`);
+    const req = httpTestingController.expectOne(`/review-notes/`);
     expect(req.request.method).toBe('POST');
     const form = req.request.body as FormData;
     expect(form.has('content')).toBeTruthy();

--- a/src/app/shared/services/records/review-note.service.ts
+++ b/src/app/shared/services/records/review-note.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { environment } from 'src/environments/environment';
 import { Record } from 'src/app/shared/interfaces/record';
 import { ReviewNote } from 'src/app/shared/interfaces/review-note';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
@@ -30,6 +29,6 @@ export class ReviewNoteService extends GenericListService {
     data.set('record', dres.id.toString());
     data.set('user', dres.user.toString());
     return this.http.post<ReviewNote>(
-      `${environment.API_URL}/review-notes/`, data);
+      `/review-notes/`, data);
   }
 }

--- a/src/app/shared/services/user.service.spec.ts
+++ b/src/app/shared/services/user.service.spec.ts
@@ -2,7 +2,6 @@ import { TestBed } from '@angular/core/testing';
 
 import { UserService } from './user.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { environment } from 'src/environments/environment';
 
 describe('UserService', () => {
   let httpTestingController: HttpTestingController;
@@ -31,7 +30,7 @@ describe('UserService', () => {
     service.getUserById(id).subscribe(() => {});
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/users/${id}/`);
+      `/users/${id}/`);
 
     expect(req.request.method).toEqual('GET');
     req.flush({});
@@ -44,7 +43,7 @@ describe('UserService', () => {
     service.getUserByUsername(username).subscribe(() => {});
 
     const req = httpTestingController.expectOne(
-      `${environment.API_URL}/users/?username=${username}`);
+      `/users/?username=${username}`);
 
     expect(req.request.method).toEqual('GET');
     req.flush({});

--- a/src/app/shared/services/user.service.ts
+++ b/src/app/shared/services/user.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { User } from '../interfaces/user';
 import { PaginatedResponse } from '../interfaces/paginated-response';
@@ -15,10 +14,10 @@ export class UserService {
   ) { }
 
   getUserById(id: number) {
-    return this.http.get<User>(`${environment.API_URL}/users/${id}/`);
+    return this.http.get<User>(`/users/${id}/`);
   }
 
   getUserByUsername(username: string) {
-    return this.http.get<PaginatedResponse<User>>(`${environment.API_URL}/users/?username=${username}`);
+    return this.http.get<PaginatedResponse<User>>(`/users/?username=${username}`);
   }
 }


### PR DESCRIPTION
As per #191, we use `environment.API_URL` many times when formatting API endpoints, it's redundant. By adding a `HttpInterceptor`, now we don't need to declare the host part of the URL for ordinary requests, the interceptor will do that for us. For external requests which are not provided by `API_URL`, callers can use absolute path for the URL, then the interceptor will just skip modifying the request.