### PR TITLE
Update to not infer return type in list method.

### DIFF
--- a/src/app/shared/generics/generic-list-service/generic-list-service.spec.ts
+++ b/src/app/shared/generics/generic-list-service/generic-list-service.spec.ts
@@ -6,6 +6,7 @@ import { HttpClient } from '@angular/common/http';
 import { GenericListService } from './generic-list-service';
 import { environment } from 'src/environments/environment';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
+import { PaginatedResponse } from '../../interfaces/paginated-response';
 
 @Injectable({
     providedIn: 'root'
@@ -18,7 +19,7 @@ class ListService extends GenericListService {
     }
 
     getObjects(url: string, req: ListRequest) {
-        return this.list<{}>(url, req);
+        return this.list<PaginatedResponse<{}>>(url, req);
     }
 }
 

--- a/src/app/shared/generics/generic-list-service/generic-list-service.ts
+++ b/src/app/shared/generics/generic-list-service/generic-list-service.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 
 import { environment } from 'src/environments/environment';
-import { PaginatedResponse } from '../../interfaces/paginated-response';
 import { ListRequest } from '../../interfaces/list-request';
 
 /** Implement generic logic for retrieving list of objects. */
@@ -24,6 +23,6 @@ export class GenericListService {
 
         // Construct final URL
         const url = `/${resourceURL}/?${queryParams}`;
-        return this.http.get<PaginatedResponse<T>>(url);
+        return this.http.get<T>(url);
     }
 }

--- a/src/app/shared/services/department.service.ts
+++ b/src/app/shared/services/department.service.ts
@@ -3,6 +3,7 @@ import { GenericListService } from '../generics/generic-list-service/generic-lis
 import { HttpClient } from '@angular/common/http';
 import { ListRequest } from '../interfaces/list-request';
 import { Department } from '../interfaces/department';
+import { PaginatedResponse } from '../interfaces/paginated-response';
 
 @Injectable({
   providedIn: 'root'
@@ -16,7 +17,7 @@ export class DepartmentService extends GenericListService {
   }
 
   getDepartments (req: ListRequest) {
-    return this.list<Department>('departments', req);
+    return this.list<PaginatedResponse<Department>>('departments', req);
   }
 
   getDepartment(id: Department|number) {

--- a/src/app/shared/services/events/event.service.ts
+++ b/src/app/shared/services/events/event.service.ts
@@ -30,7 +30,7 @@ export class EventService extends GenericListService {
   /** Retrieve campus events. */
   /** TODO(youchen): Rename this function */
   getCampusEvents(req: ListRequest) {
-    return this.list<CampusEvent>('campus-events', req);
+    return this.list<PaginatedResponse<CampusEvent>>('campus-events', req);
   }
 
   /** Retrieve campus events on ID */
@@ -71,7 +71,7 @@ export class EventService extends GenericListService {
   }
   /** Retrieve off-campus events, it's frequently used in AutoComplete. */
   getOffCampusEvents(req: ListRequest) {
-    return this.list<OffCampusEvent>('off-campus-events', req);
+    return this.list<PaginatedResponse<OffCampusEvent>>('off-campus-events', req);
   }
 
   /**  Admin create campus event */

--- a/src/app/shared/services/notification.service.ts
+++ b/src/app/shared/services/notification.service.ts
@@ -8,6 +8,7 @@ import { Notification } from 'src/app/shared/interfaces/notification';
 import { AUTH_SERVICE, AuthService } from 'src/app/shared/interfaces/auth-service';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
+import { PaginatedResponse } from '../interfaces/paginated-response';
 
 
 @Injectable({
@@ -48,17 +49,17 @@ export class NotificationService extends GenericListService {
 
   /** API for retrieving notifications. */
   getNotifications(req: ListRequest) {
-    return this.list<Notification>('notifications', req);
+    return this.list<PaginatedResponse<Notification>>('notifications', req);
   }
 
   /** API for retrieving notifications which have been read. */
   getReadNotifications(req: ListRequest) {
-    return this.list<Notification>('notifications/read', req);
+    return this.list<PaginatedResponse<Notification>>('notifications/read', req);
   }
 
   /** API for retrieving notifications which haven't been read. */
   getUnReadNotifications(req: ListRequest) {
-    return this.list<Notification>('notifications/unread', req);
+    return this.list<PaginatedResponse<Notification>>('notifications/unread', req);
   }
 
   /** Mark all notifications for user as read. */

--- a/src/app/shared/services/programs/program.service.ts
+++ b/src/app/shared/services/programs/program.service.ts
@@ -9,6 +9,7 @@ import { GenericListService } from 'src/app/shared/generics/generic-list-service
 import { DepartmentService } from 'src/app/shared/services/department.service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
 import { Observable, of as observableOf } from 'rxjs';
+import { PaginatedResponse } from '../../interfaces/paginated-response';
 
 @Injectable({
   providedIn: 'root'
@@ -26,7 +27,7 @@ export class ProgramService extends GenericListService {
 
   /** get the information of programs from the background. */
   getPrograms(req: ListRequest) {
-    return this.list<Program>('programs', req);
+    return this.list<PaginatedResponse<Program>>('programs', req);
   }
 
   /** get the information of one program from the background. */

--- a/src/app/shared/services/records/record.service.ts
+++ b/src/app/shared/services/records/record.service.ts
@@ -103,7 +103,7 @@ export class RecordService extends GenericListService {
   }
 
   getRecords(url: string, req: ListRequest) {
-    return this.list<Record>(url, req);
+    return this.list<PaginatedResponse<Record>>(url, req);
   }
 
   getRecordsWithDetail(url: string, req: ListRequest) {

--- a/src/app/shared/services/records/review-note.service.ts
+++ b/src/app/shared/services/records/review-note.service.ts
@@ -6,6 +6,7 @@ import { Record } from 'src/app/shared/interfaces/record';
 import { ReviewNote } from 'src/app/shared/interfaces/review-note';
 import { GenericListService } from 'src/app/shared/generics/generic-list-service/generic-list-service';
 import { ListRequest } from 'src/app/shared/interfaces/list-request';
+import { PaginatedResponse } from '../../interfaces/paginated-response';
 
 /** Provide services for Review Note. */
 @Injectable({
@@ -20,7 +21,7 @@ export class ReviewNoteService extends GenericListService {
   }
 
   getReviewNotes(req: ListRequest) {
-    return this.list<ReviewNote>('review-notes', req);
+    return this.list<PaginatedResponse<ReviewNote>>('review-notes', req);
   }
 
   createReviewNote(dres: Record, notecontent: string): Observable<ReviewNote> {


### PR DESCRIPTION
If backend server receives `limit=-1`, then it won't paginate the response, instead it will return the full list, but our implementation of `list` method in `GenericListService` doesn't support this feature, so we need to let the caller to determine the type.